### PR TITLE
fix: string escaping comment, honor analysis_options.yaml excludes and use mason_logger

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -152,11 +152,13 @@ runs:
       id: prepare_comment
       env:
         PR_COMMENT: ${{ steps.prepare_comment.outputs.PR_COMMENT }}
+        PR_COMMENT_MESSAGE: ${{ inputs.pr_comment_message }}
+        NEW_VERSION: ${{ inputs.new_version }}
       with:
         result-encoding: string
         script: |
-          const message = '${{ inputs.pr_comment_message }}'
-            .replace('{version}', '${{ inputs.new_version }}')
+          const message = process.env.PR_COMMENT_MESSAGE
+            .replace('{version}', process.env.NEW_VERSION)
             .replace('{changelog}', process.env.API_CHANGELOG);
           return message;
 

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: "Whether to fail the workflow on error"
     required: false
     default: "true"
+  mtrust_api_guard_ref:
+    description: "Git reference to use for mtrust-api-guard"
+    required: false
+    default: "main"
 
 outputs:
   api_change_type:
@@ -52,7 +56,7 @@ runs:
 
     - name: Install M-Trust API Guard from Git
       shell: bash
-      run: dart pub global activate --source git https://github.com/emdgroup/mtrust-api-guard.git
+      run: dart pub global activate --source git https://github.com/emdgroup/mtrust-api-guard.git --git-ref ${{ inputs.mtrust_api_guard_ref }}
 
     - name: Generate new API docs
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -4,42 +4,42 @@ author: "emdgroup"
 
 inputs:
   src_path:
-    description: 'Source path to generate the documentation'
+    description: "Source path to generate the documentation"
     required: true
     default: "./lib"
   base_doc:
-    description: 'Path / ref to base documentation.dart file'
+    description: "Path / ref to base documentation.dart file"
     required: true
     default: "origin/main:documentation.g.dart"
   new_doc:
-    description: 'Path to new documentation.dart file'
+    description: "Path to new documentation.dart file"
     required: true
     default: "documentation.g.dart"
   new_version:
-    description: 'New version to be validated'
+    description: "New version to be validated"
     required: true
   comment_on_pr:
-    description: 'Whether to add comments to the PR with API changes'
+    description: "Whether to add comments to the PR with API changes"
     required: false
-    default: 'true'
+    default: "true"
   pr_comment_message:
-    description: 'Custom message template for PR comments. Use {version} and {changelog} as placeholders.'
+    description: "Custom message template for PR comments. Use {version} and {changelog} as placeholders."
     required: false
     default: "New version {version} 🚀\n\nDetected API changes:\n{changelog}"
   fail_on_error:
-    description: 'Whether to fail the workflow on error'
+    description: "Whether to fail the workflow on error"
     required: false
-    default: 'true'
+    default: "true"
 
 outputs:
   api_change_type:
-    description: 'Detected API change type (major, minor, patch)'
+    description: "Detected API change type (major, minor, patch)"
     value: ${{ steps.detect_change_type.outputs.api_change_type }}
   api_changelog:
-    description: 'Generated API changelog'
+    description: "Generated API changelog"
     value: ${{ steps.detect_change_type.outputs.api_changelog }}
   validation_passed:
-    description: 'Whether the version validation passed'
+    description: "Whether the version validation passed"
     value: ${{ steps.validate_version.outputs.validation_passed }}
 
 runs:
@@ -72,18 +72,18 @@ runs:
           --magnitude patch)
         COMPARE_EXIT_CODE=$?
         set -e  # Resume exit on error
-        
+
         if [[ $COMPARE_EXIT_CODE -ne 0 && "${{ inputs.fail_on_error }}" == "true" ]]; then
           echo "Error in API comparison and fail_on_error is true"
           exit $COMPARE_EXIT_CODE
         fi
-        
+
         API_CHANGE_TYPE=$(echo "$API_CHANGELOG" | head -n 1 | grep -oE "major|minor|patch" || echo "patch")
         echo "api_change_type=$API_CHANGE_TYPE" >> $GITHUB_OUTPUT
         echo "api_changelog<<EOF" >> $GITHUB_OUTPUT
         echo "$API_CHANGELOG" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-        
+
         echo "API_CHANGE_TYPE=$API_CHANGE_TYPE" >> $GITHUB_ENV
         {
           echo 'API_CHANGELOG<<EOF'
@@ -111,7 +111,7 @@ runs:
       run: |
         IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<< "$PREVIOUS_VERSION"
         IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "${{ inputs.new_version }}"
-        
+
         if [[ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]]; then
           DETECTED_CHANGE="major"
         elif [[ "$NEW_MINOR" -gt "$OLD_MINOR" ]]; then
@@ -120,7 +120,7 @@ runs:
           DETECTED_CHANGE="patch"
         fi
         echo "Expected: At least $API_CHANGE_TYPE | Detected: $DETECTED_CHANGE"
-        
+
         PRIORITY_MAP=("patch" "minor" "major")
         for i in "${!PRIORITY_MAP[@]}"; do
           [[ "${PRIORITY_MAP[$i]}" == "$API_CHANGE_TYPE" ]] && EXPECTED_INDEX=$i
@@ -148,23 +148,24 @@ runs:
 
     - name: Prepare PR comment content
       if: ${{ inputs.comment_on_pr == 'true' }}
-      shell: bash
-      run: |
-        # Create the comment by replacing placeholders
-        COMMENT="${{ inputs.pr_comment_message }}"
-        COMMENT="${COMMENT/\{version\}/${{ inputs.new_version }}}"
-        COMMENT="${COMMENT/\{changelog\}/${{ env.API_CHANGELOG }}}"
-        echo "PR_COMMENT<<EOF" >> $GITHUB_ENV
-        echo "$COMMENT" >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
+      uses: actions/github-script@v7
+      id: prepare_comment
+      env:
+        PR_COMMENT: ${{ steps.prepare_comment.outputs.PR_COMMENT }}
+      with:
+        result-encoding: string
+        script: |
+          const message = '${{ inputs.pr_comment_message }}'
+            .replace('{version}', '${{ inputs.new_version }}')
+            .replace('{changelog}', process.env.API_CHANGELOG);
+          return message;
 
     - name: Comment on PR with new version and API changelog
       if: ${{ inputs.comment_on_pr == 'true' }}
       uses: thollander/actions-comment-pull-request@v3
       with:
         comment-tag: api_guard_comment
-        message: ${{ env.PR_COMMENT }}
-
+        message: ${{ steps.prepare_comment.outputs.result }}
 
 branding:
   icon: "shield"

--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,8 @@ runs:
           --path ${{ inputs.src_path }} \
           --output ${{ inputs.new_doc }} || if [[ "${{ inputs.fail_on_error }}" == "true" ]]; then exit 1; else echo "Ignoring error as fail_on_error is false"; fi
 
+        cat ${{ inputs.new_doc }}
+
     - name: Run API change type detection
       id: detect_change_type
       shell: bash

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,7 @@ include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+linter:
+  rules:
+    avoid_print: false

--- a/lib/doc_generator/detect_exclusions.dart
+++ b/lib/doc_generator/detect_exclusions.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
+import 'package:mtrust_api_guard/doc_generator/find_project_root.dart';
+import 'package:path/path.dart';
+import 'package:yaml/yaml.dart';
+
+Future<Set<String>> detectExclusions(String path) async {
+  final root = await findProjectRoot(path);
+
+  final analysisOptions = File('${root.path}/analysis_options.yaml');
+
+  final exclusions = <String>{};
+
+  if (!analysisOptions.existsSync()) {
+    print(
+        'analysis_options.yaml not found in ${root.path}. No files will be excluded.');
+  } else {
+    final analysisOptionsContent = analysisOptions.readAsStringSync();
+    final yaml = loadYaml(analysisOptionsContent);
+
+    final exclude = yaml['analyzer']['exclude'] as YamlList?;
+
+    if (exclude != null) {
+      for (final path in exclude) {
+        var pattern = Glob(path);
+        for (final file in pattern.listSync()) {
+          exclusions.add(normalize(file.path));
+        }
+      }
+    }
+  }
+
+  return exclusions;
+}

--- a/lib/doc_generator/find_project_root.dart
+++ b/lib/doc_generator/find_project_root.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+import 'dart:io';
+
+Future<Directory> findProjectRoot(String path) async {
+  var currentDir = Directory(path);
+
+  while (currentDir.path.split("/").length > 1) {
+    if (File('${currentDir.path}/pubspec.yaml').existsSync()) {
+      return currentDir;
+    }
+    currentDir = currentDir.parent;
+  }
+
+  throw Exception('pubspec.yaml not found in $path');
+}

--- a/lib/doc_generator/library_types.dart
+++ b/lib/doc_generator/library_types.dart
@@ -1,0 +1,78 @@
+/// The types used in the generated library. Same as in `doc_items.dart`.
+/// It might be cleaner to load this from an asset file, but for now we
+/// keep it here to avoid adding more dependencies.
+const libraryTypes = """
+class DocComponent {
+  const DocComponent({
+    required this.name,
+    required this.isNullSafe,
+    required this.description,
+    required this.constructors,
+    required this.properties,
+    required this.methods,
+  });
+
+  final String name;
+
+  final bool isNullSafe;
+
+  final String description;
+
+  final List<DocConstructor> constructors;
+
+  final List<DocProperty> properties;
+
+  final List<String> methods;
+}
+
+class DocProperty {
+  const DocProperty({
+    required this.name,
+    required this.type,
+    required this.description,
+    required this.features,
+  });
+
+  final String name;
+
+  final String type;
+
+  final String description;
+
+  final List<String> features;
+}
+
+class DocConstructor {
+  const DocConstructor({
+    required this.name,
+    required this.signature,
+    required this.features,
+  });
+
+  final String name;
+
+  final List<DocParameter> signature;
+
+  final List<String> features;
+}
+
+class DocParameter {
+  const DocParameter({
+    required this.name,
+    required this.type,
+    required this.description,
+    required this.named,
+    required this.required,
+  });
+
+  final String name;
+
+  final String description;
+
+  final String type;
+
+  final bool named;
+
+  final bool required;
+}
+""";

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -1,0 +1,3 @@
+import 'package:mason_logger/mason_logger.dart';
+
+final logger = Logger();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   analyzer: ^6.2.0
   build: ^2.4.1
   code_builder: ^4.8.0
-  glob: ^2.0.2
+  glob: ^2.1.3
   build_config: ^1.1.1
   source_gen: ^1.4.0
   dart_style: ^2.3.4
@@ -17,5 +17,7 @@ dependencies:
   args: ^2.4.0
   path: ^1.9.1
   collection: ^1.19.1
+  yaml: ^3.1.3
+  mason_logger: ^0.3.3
 executables:
   mtrust_api_guard:


### PR DESCRIPTION
This PR fixes some failing runs I discovered 

* The changelog previously was assembled using a bash script which could fail if the changelog included quotes, causing a part of the changelog becoming interpreted as commands 
*  The generate command would sometimes fail if the analysis context was created without passing the files which were previously ignored in the analysis_options.yaml file. This might be due to the analysis server caching the symbols. To prevent this this PR adds the option to exclude files and a new default behaviour that locates the analysis options file and extracts the ignore files from it. 
* To improve the feedback given from the tool  mason logger was added to the generate command which gives some progress indication and colors the output of the tool. 