### PR TITLE
fix: add annotation message to git tag command

### DIFF
--- a/lib/doc_generator/git_utils.dart
+++ b/lib/doc_generator/git_utils.dart
@@ -173,7 +173,7 @@ class GitUtils {
   }
 
   static Future<void> gitTag(String tag, String? root) async {
-    final result = await Process.run('git', ['tag', tag], workingDirectory: root);
+    final result = await Process.run('git', ['tag', '-a', tag, '-m', 'Release $tag'], workingDirectory: root);
     if (result.exitCode != 0) {
       throw GitException('Failed to tag $tag: ${result.stderr.toString()}');
     }


### PR DESCRIPTION
This is necessary, so that the `--follow-tags` param from the `publish_workflow.yaml` succeeds.