### PR TITLE
fix(version): increment pre-release suffix on same stable base

### DIFF
--- a/lib/version/calculate_next_version.dart
+++ b/lib/version/calculate_next_version.dart
@@ -5,6 +5,73 @@ import 'package:mtrust_api_guard/doc_generator/git_utils.dart';
 import 'package:mtrust_api_guard/logger.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+Version stableVersion(Version version) => Version(version.major, version.minor, version.patch);
+
+Version targetStableForPreRelease(Version original, ApiChangeMagnitude magnitude) {
+  final stable = stableVersion(original);
+  if (original.isPreRelease && magnitude == ApiChangeMagnitude.patch) {
+    return stable;
+  }
+  return bumpStable(stable, magnitude);
+}
+
+Version bumpStable(Version stable, ApiChangeMagnitude magnitude) {
+  switch (magnitude) {
+    case ApiChangeMagnitude.major:
+      return stable.nextMajor;
+    case ApiChangeMagnitude.minor:
+      return stable.nextMinor;
+    case ApiChangeMagnitude.patch:
+      return stable.nextPatch;
+    case ApiChangeMagnitude.ignore:
+      return stable;
+  }
+}
+
+Version incrementPreRelease(Version version) {
+  final parts = List<Object>.from(version.preRelease);
+  final last = parts.last;
+  final incremented = last is int ? last + 1 : int.parse(last.toString()) + 1;
+  parts[parts.length - 1] = incremented;
+  final pre = parts.map((part) => part.toString()).join('.');
+  return Version(version.major, version.minor, version.patch, pre: pre);
+}
+
+Version initialPreRelease(Version stable, Version? template, String preReleasePrefix) {
+  if (template != null && template.isPreRelease) {
+    final parts = List<Object>.from(template.preRelease);
+    if (parts.length == 1 && parts[0] is int) {
+      return Version(stable.major, stable.minor, stable.patch, pre: '1');
+    }
+    final newParts = List<Object>.from(parts);
+    newParts[newParts.length - 1] = 1;
+    final pre = newParts.map((part) => part.toString()).join('.');
+    return Version(stable.major, stable.minor, stable.patch, pre: pre);
+  }
+
+  final normalizedPrefix = preReleasePrefix.trim();
+  final separator = normalizedPrefix.isEmpty || normalizedPrefix.endsWith('.') ? '' : '.';
+  final pre = normalizedPrefix.isEmpty ? '1' : '$normalizedPrefix${separator}1';
+  return Version(stable.major, stable.minor, stable.patch, pre: pre);
+}
+
+Version applyMagnitudeBump(Version version, ApiChangeMagnitude magnitude) {
+  switch (magnitude) {
+    case ApiChangeMagnitude.major:
+      logger.info('Incrementing major version');
+      return version.nextMajor;
+    case ApiChangeMagnitude.minor:
+      logger.info('Incrementing minor version');
+      return version.nextMinor;
+    case ApiChangeMagnitude.patch:
+      logger.info('Incrementing patch version');
+      return version.nextPatch;
+    case ApiChangeMagnitude.ignore:
+      logger.info('No version increment for ignore magnitude');
+      return version;
+  }
+}
+
 Future<String> calculateNextVersion(
   Version version,
   ApiChangeMagnitude highestMagnitudeChange,
@@ -14,47 +81,41 @@ Future<String> calculateNextVersion(
   String preReleasePrefix,
 ) async {
   logger.info('Current version: $version');
+  final originalVersion = version;
 
-  switch (highestMagnitudeChange) {
-    case ApiChangeMagnitude.major:
-      logger.info('Incrementing major version');
-      version = version.nextMajor;
-      break;
-    case ApiChangeMagnitude.minor:
-      logger.info('Incrementing minor version');
-      version = version.nextMinor;
-      break;
-    case ApiChangeMagnitude.patch:
-      logger.info('Incrementing patch version');
-      version = version.nextPatch;
-      break;
-    case ApiChangeMagnitude.ignore:
-      logger.info('No version increment for ignore magnitude');
-      break;
+  if (isPreRelease) {
+    if (highestMagnitudeChange == ApiChangeMagnitude.ignore) {
+      return originalVersion.toString();
+    }
+
+    final originalStable = stableVersion(originalVersion);
+    final bumpedStable = targetStableForPreRelease(originalVersion, highestMagnitudeChange);
+
+    logger.info('New version: $bumpedStable');
+
+    if (originalVersion.isPreRelease && bumpedStable == originalStable) {
+      final next = incrementPreRelease(originalVersion);
+      logger.info('Pre-release version: $next');
+      return next.toString();
+    }
+
+    var candidate = initialPreRelease(
+      bumpedStable,
+      originalVersion.isPreRelease ? originalVersion : null,
+      preReleasePrefix,
+    );
+    while (await GitUtils.gitTagExists('$tagPrefix$candidate', gitRoot.path)) {
+      candidate = incrementPreRelease(candidate);
+    }
+    logger.info('Pre-release version: $candidate');
+    return candidate.toString();
   }
 
-  final newVersion = version.toString();
+  final newVersion = applyMagnitudeBump(version, highestMagnitudeChange).toString();
 
   logger.info('New version: $newVersion');
 
-  if (isPreRelease) {
-    final normalizedPrefix = preReleasePrefix.trim();
-    final separator = normalizedPrefix.isEmpty || normalizedPrefix.endsWith('.') ? '' : '.';
-    String buildPreReleaseSuffix(int number) {
-      if (normalizedPrefix.isEmpty) {
-        return '$number';
-      }
-      return '$normalizedPrefix$separator$number';
-    }
-
-    var preReleaseNum = 1;
-    while (await GitUtils.gitTagExists('$tagPrefix$newVersion-${buildPreReleaseSuffix(preReleaseNum)}', gitRoot.path)) {
-      preReleaseNum++;
-    }
-    final preReleaseVersion = '$newVersion-${buildPreReleaseSuffix(preReleaseNum)}';
-    logger.info('Pre-release version: $preReleaseVersion');
-    return preReleaseVersion;
-  } else if (await GitUtils.gitTagExists('$tagPrefix$newVersion', gitRoot.path)) {
+  if (await GitUtils.gitTagExists('$tagPrefix$newVersion', gitRoot.path)) {
     logger.err('Version tag $tagPrefix$newVersion already exists');
     throw Exception('Version tag $tagPrefix$newVersion already exists');
   }

--- a/lib/version/version.dart
+++ b/lib/version/version.dart
@@ -99,14 +99,12 @@ Future<VersionResult> version({
 
   logger.info('Highest magnitude change: $highestMagnitudeChange');
 
-  // For workspace packages, extract the 'v' prefix from tagPrefix (which is like 'package/v')
-  final versionTagPrefix = packageName != null ? 'v' : tagPrefix;
   final nextVersion = await calculateNextVersion(
     baseVersion,
     highestMagnitudeChange,
     isPreRelease,
     gitRoot,
-    versionTagPrefix,
+    tagPrefix,
     preReleasePrefix,
   );
 

--- a/test/version/calculate_next_version_test.dart
+++ b/test/version/calculate_next_version_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:mtrust_api_guard/doc_comparator/api_change.dart';
+import 'package:mtrust_api_guard/version/calculate_next_version.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('incrementPreRelease', () {
+    test('increments numeric pre-release suffix', () {
+      final version = Version.parse('23.0.0-3');
+      expect(incrementPreRelease(version).toString(), '23.0.0-4');
+    });
+
+    test('increments dev pre-release suffix', () {
+      final version = Version.parse('0.1.0-dev.1');
+      expect(incrementPreRelease(version).toString(), '0.1.0-dev.2');
+    });
+  });
+
+  group('calculateNextVersion pre-release', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('calculate_next_version_test_');
+      await Process.run('git', ['init'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'user.email', 'test@example.com'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'user.name', 'Test'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'commit.gpgsign', 'false'], workingDirectory: tempDir.path);
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    Future<void> createTag(String tag) async {
+      final commitResult = await Process.run(
+        'git',
+        ['commit', '--allow-empty', '-m', tag],
+        workingDirectory: tempDir.path,
+      );
+      expect(commitResult.exitCode, 0, reason: commitResult.stderr.toString());
+      final tagResult = await Process.run('git', ['tag', tag], workingDirectory: tempDir.path);
+      expect(tagResult.exitCode, 0, reason: tagResult.stderr.toString());
+    }
+
+    test('increments numeric pre-release on same stable base', () async {
+      await createTag('liquid_flutter/v23.0.0-1');
+      await createTag('liquid_flutter/v23.0.0-2');
+      await createTag('liquid_flutter/v23.0.0-3');
+
+      final next = await calculateNextVersion(
+        Version.parse('23.0.0-3'),
+        ApiChangeMagnitude.patch,
+        true,
+        tempDir,
+        'liquid_flutter/v',
+        '',
+      );
+
+      expect(next, '23.0.0-4');
+    });
+
+    test('starts pre-release for first pre-release bump', () async {
+      final next = await calculateNextVersion(
+        Version.parse('0.0.1'),
+        ApiChangeMagnitude.minor,
+        true,
+        tempDir,
+        'v',
+        '',
+      );
+
+      expect(next, '0.1.0-1');
+    });
+
+    test('starts dev pre-release with custom prefix', () async {
+      final next = await calculateNextVersion(
+        Version.parse('0.0.1'),
+        ApiChangeMagnitude.minor,
+        true,
+        tempDir,
+        'v',
+        'dev',
+      );
+
+      expect(next, '0.1.0-dev.1');
+    });
+
+    test('bumps stable base and restarts pre-release suffix', () async {
+      final next = await calculateNextVersion(
+        Version.parse('0.1.0-dev.3'),
+        ApiChangeMagnitude.minor,
+        true,
+        tempDir,
+        'v',
+        'dev',
+      );
+
+      expect(next, '0.2.0-dev.1');
+    });
+
+    test('increments dev pre-release on same stable base', () async {
+      final next = await calculateNextVersion(
+        Version.parse('0.1.0-dev.1'),
+        ApiChangeMagnitude.patch,
+        true,
+        tempDir,
+        'v',
+        'dev',
+      );
+
+      expect(next, '0.1.0-dev.2');
+    });
+
+    test('skips existing tags when choosing next pre-release', () async {
+      await createTag('v0.1.0-1');
+
+      final next = await calculateNextVersion(
+        Version.parse('0.0.1'),
+        ApiChangeMagnitude.minor,
+        true,
+        tempDir,
+        'v',
+        '',
+      );
+
+      expect(next, '0.1.0-2');
+    });
+  });
+
+  group('calculateNextVersion release', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('calculate_next_version_release_test_');
+      await Process.run('git', ['init'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'commit.gpgsign', 'false'], workingDirectory: tempDir.path);
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('finalizes pre-release to stable version', () async {
+      final next = await calculateNextVersion(
+        Version.parse('1.0.0-dev.1'),
+        ApiChangeMagnitude.patch,
+        false,
+        tempDir,
+        'v',
+        'dev',
+      );
+
+      expect(next, '1.0.0');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fix pre-release version calculation to increment the existing suffix on the same stable base (e.g. `23.0.0-3` → `23.0.0-4`) instead of resetting to `-1`
- Pass the full workspace tag prefix (`liquid_flutter/v`) when checking for existing tags, so tag collisions are detected correctly
- Preserve existing pre-release formats (numeric `-N` and custom prefixes like `dev.N`) when bumping

## Test plan
- [x] `dart test test/version/calculate_next_version_test.dart`
- [x] Verify workspace pre-release bump in CI (`version-workspace --pre-release`)