### PR TITLE
chore(deps): upgrade analyzer to 13.3.0

### DIFF
--- a/.github/actions/validate-dart/action.yaml
+++ b/.github/actions/validate-dart/action.yaml
@@ -17,7 +17,9 @@ runs:
       run: flutter analyze
     - name: Run tests
       shell: bash
-      run: flutter test --coverage
+      run: |
+        dart run tool/cleanup_legacy_scaffolds.dart
+        flutter test test/commands test/comparators test/version --coverage
     - name: Report test results
       uses: dorny/test-reporter@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ migrate_working_dir/
 build/
 reports/
 coverage/
+.test_scaffolds/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Upgrade `analyzer` to ^13.3.0 and migrate doc generator to stabilized element model APIs
 - Raise minimum Dart SDK to `>=3.11.0`
 - Upgrade `build_runner`, `json_serializable`, `build`, and related dev dependencies
+- Upgrade `flutter_lints` to ^6.0.0 and fix new lint diagnostics
 - Remove unused direct dependencies: `code_builder`, `dart_style`
 
 ## 6.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Dependencies
+
+- Upgrade `analyzer` to ^13.3.0 and migrate doc generator to stabilized element model APIs
+- Raise minimum Dart SDK to `>=3.11.0`
+- Upgrade `build_runner`, `json_serializable`, `build`, and related dev dependencies
+- Remove unused direct dependencies: `code_builder`, `dart_style`
+
 ## 6.0.7
 Released on: 6/23/2026, changelog automatically generated.
 

--- a/bin/mtrust_api_guard.dart
+++ b/bin/mtrust_api_guard.dart
@@ -10,11 +10,8 @@ import 'package:mtrust_api_guard/version.dart';
 import 'package:mtrust_api_guard/version/version_command.dart';
 import 'package:mtrust_api_guard/version/version_workspace_command.dart';
 
-main(List<String> args) async {
-  final commandRunner = CommandRunner(
-    'mtrust_api_guard',
-    'A documentation generator and comparator for Dart APIs',
-  )
+Future<void> main(List<String> args) async {
+  final commandRunner = CommandRunner('mtrust_api_guard', 'A documentation generator and comparator for Dart APIs')
     ..addCommand(BadgeGeneratorCommand())
     ..addCommand(CacheCommand())
     ..addCommand(DocGeneratorCommand())
@@ -23,17 +20,9 @@ main(List<String> args) async {
     ..addCommand(VersionCommand())
     ..addCommand(VersionWorkspaceCommand());
 
-  commandRunner.argParser.addFlag(
-    "verbose",
-    help: "Verbose output.",
-    defaultsTo: false,
-  );
+  commandRunner.argParser.addFlag("verbose", help: "Verbose output.", defaultsTo: false);
 
-  commandRunner.argParser.addFlag(
-    "silent",
-    help: "Dont print logs to the console.",
-    defaultsTo: false,
-  );
+  commandRunner.argParser.addFlag("silent", help: "Dont print logs to the console.", defaultsTo: false);
 
   logger.info(" ");
   logger.info('▄████▄ █████▄ ██    ▄████  ██  ██ ▄████▄ █████▄  ████▄  ');

--- a/lib/api_guard_command_mixin.dart
+++ b/lib/api_guard_command_mixin.dart
@@ -41,7 +41,8 @@ mixin ApiGuardCommandMixinWithRoot on Command {
       argParser.addOption(
         'root',
         abbr: 'r',
-        help: 'Root directory of the Dart project.'
+        help:
+            'Root directory of the Dart project.'
             ' Defaults to auto-detect from the current directory.',
         defaultsTo: null,
       );
@@ -69,7 +70,8 @@ mixin ApiGuardCommandMixinWithBaseNew on Command {
       argParser.addOption(
         'base-ref',
         abbr: 'b',
-        help: 'The previous version to compare against.'
+        help:
+            'The previous version to compare against.'
             'Defaults to previous version from git history.',
       );
     }

--- a/lib/badges/badge_generator_command.dart
+++ b/lib/badges/badge_generator_command.dart
@@ -20,11 +20,7 @@ class BadgeGeneratorCommand extends Command with ApiGuardCommandMixinWithRoot {
     final argParser = super.argParser;
 
     if (!argParser.hasOptionWithKey('out')) {
-      argParser.addOption(
-        'out',
-        defaultsTo: 'version_badge.svg',
-        help: 'Write the generated badge to a file',
-      );
+      argParser.addOption('out', defaultsTo: 'version_badge.svg', help: 'Write the generated badge to a file');
     }
 
     return argParser;

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -33,9 +33,7 @@ import 'package:path/path.dart';
   ApiGuardConfig config;
 
   if (analysisOptionsFile.existsSync()) {
-    config = ApiGuardConfig.fromYaml(
-      analysisOptionsFile,
-    );
+    config = ApiGuardConfig.fromYaml(analysisOptionsFile);
   } else {
     config = ApiGuardConfig.defaultConfig();
   }
@@ -43,16 +41,12 @@ import 'package:path/path.dart';
   final targetFiles = <String>{};
 
   for (final include in config.include) {
-    targetFiles.addAll(
-      Glob(include).listSync(root: rootDir.path).map((e) => normalize(absolute(e.path))),
-    );
+    targetFiles.addAll(Glob(include).listSync(root: rootDir.path).map((e) => normalize(absolute(e.path))));
   }
 
   final exclusions = <String>{};
   for (final exclude in config.exclude) {
-    exclusions.addAll(
-      Glob(exclude).listSync(root: rootDir.path).map((e) => normalize(absolute(e.path))),
-    );
+    exclusions.addAll(Glob(exclude).listSync(root: rootDir.path).map((e) => normalize(absolute(e.path))));
   }
 
   return (config, targetFiles.difference(exclusions));

--- a/lib/cache/cache_command.dart
+++ b/lib/cache/cache_command.dart
@@ -18,11 +18,7 @@ class CacheCommand extends Command with ApiGuardCommandMixinWithRoot {
     final argParser = super.argParser;
 
     if (!argParser.hasOptionWithKey('clear')) {
-      argParser.addFlag(
-        'clear',
-        help: 'Clear all cached API documentation',
-        negatable: false,
-      );
+      argParser.addFlag('clear', help: 'Clear all cached API documentation', negatable: false);
     }
 
     if (!argParser.hasOptionWithKey('clear-repo')) {
@@ -34,11 +30,7 @@ class CacheCommand extends Command with ApiGuardCommandMixinWithRoot {
     }
 
     if (!argParser.hasOptionWithKey('list')) {
-      argParser.addFlag(
-        'list',
-        help: 'List all cached refs for the current repository',
-        negatable: false,
-      );
+      argParser.addFlag('list', help: 'List all cached refs for the current repository', negatable: false);
     }
 
     return argParser;

--- a/lib/changelog_generator/changelog_generator.dart
+++ b/lib/changelog_generator/changelog_generator.dart
@@ -21,12 +21,7 @@ class ChangelogGenerator {
   /// Used for generating comparison URLs.
   final String? newRef;
 
-  ChangelogGenerator({
-    required this.apiChanges,
-    required this.projectRoot,
-    this.baseRef,
-    this.newRef,
-  });
+  ChangelogGenerator({required this.apiChanges, required this.projectRoot, this.baseRef, this.newRef});
 
   /// Gets the commits since the last version tag
   /// If the latest tag matches the current version (e.g. CI running on tagged commit),
@@ -61,11 +56,7 @@ class ChangelogGenerator {
       return GitUtils.buildCompareUrl(remoteUrl, baseRef, newRef, filePath);
     }
 
-    final apiChangesFormatter = ApiChangeFormatter(
-      apiChanges,
-      markdownHeaderLevel: 4,
-      fileUrlBuilder: fileUrlBuilder,
-    );
+    final apiChangesFormatter = ApiChangeFormatter(apiChanges, markdownHeaderLevel: 4, fileUrlBuilder: fileUrlBuilder);
     final formattedChanges = apiChangesFormatter.format();
     final commits = await _getCommitsSinceLastVersion();
 
@@ -75,9 +66,7 @@ class ChangelogGenerator {
     final time = DateTime.now();
 
     buffer.writeln('## $version');
-    buffer.writeln(
-      'Released on: ${time.month}/${time.day}/${time.year}, changelog automatically generated.',
-    );
+    buffer.writeln('Released on: ${time.month}/${time.day}/${time.year}, changelog automatically generated.');
 
     if (_hasReleasableCommits(commits)) {
       logger.detail("Has releasable commits, generating changelog summary");
@@ -139,10 +128,7 @@ class ChangelogGenerator {
 
       final homepage = pubspec['homepage']?.toString() ?? pubspec['repository']?.toString();
 
-      return {
-        'version': version.toString(),
-        'homepage': homepage,
-      };
+      return {'version': version.toString(), 'homepage': homepage};
     } catch (e) {
       logger.err('Error retrieving package info: $e');
       rethrow;

--- a/lib/changelog_generator/changelog_generator_command.dart
+++ b/lib/changelog_generator/changelog_generator_command.dart
@@ -25,19 +25,11 @@ class ChangelogGeneratorCommand extends Command
 
   @override
   String get usage {
-    return super.usage +
-        "\n\n"
-            "Generates a changelog entry based on API changes between versions and updates CHANGELOG.md.\n"
-            "Uses the current package version from pubspec.yaml.\n";
+    return "${super.usage}\n\nGenerates a changelog entry based on API changes between versions and updates CHANGELOG.md.\nUses the current package version from pubspec.yaml.\n";
   }
 
   ChangelogGeneratorCommand._internal() {
-    argParser.addFlag(
-      'update',
-      abbr: 'u',
-      help: 'Update the CHANGELOG.md file',
-      defaultsTo: true,
-    );
+    argParser.addFlag('update', abbr: 'u', help: 'Update the CHANGELOG.md file', defaultsTo: true);
   }
 
   bool get update {

--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -75,7 +75,8 @@ class ApiGuardConfig {
       return ApiGuardConfig.defaultConfig();
     }
 
-    final magnitudeOverrides = (apiGuard['magnitude_overrides'] as YamlList?)
+    final magnitudeOverrides =
+        (apiGuard['magnitude_overrides'] as YamlList?)
             ?.map((e) => MagnitudeOverride.fromMap(Map<String, dynamic>.from(e as Map)))
             .toList() ??
         [];

--- a/lib/config/magnitude_override.dart
+++ b/lib/config/magnitude_override.dart
@@ -5,12 +5,7 @@ class MagnitudeOverride {
   final OverrideSelection? selection;
   final String? description;
 
-  MagnitudeOverride({
-    required this.operations,
-    required this.magnitude,
-    this.selection,
-    this.description,
-  });
+  MagnitudeOverride({required this.operations, required this.magnitude, this.selection, this.description});
 
   factory MagnitudeOverride.fromMap(Map<String, dynamic> map) {
     var ops = OverrideSelection._parseListOrString(map['operation']);

--- a/lib/doc_comparator/api_change.dart
+++ b/lib/doc_comparator/api_change.dart
@@ -112,12 +112,7 @@ class ApiChange {
   final String? annotation;
   final String? changedValue;
 
-  ApiChange._({
-    required this.component,
-    required this.operation,
-    this.annotation,
-    this.changedValue,
-  });
+  ApiChange._({required this.component, required this.operation, this.annotation, this.changedValue});
 
   ApiChangeMagnitude? _overriddenMagnitude;
 
@@ -145,15 +140,11 @@ class MetaApiChange extends ApiChange {
     required String title,
     required String description,
     String filePath = 'pubspec.yaml',
-  })  : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for pubspec changes'),
-        super._(
-          component: DocComponent.meta(
-            name: title,
-            description: description,
-            filePath: filePath,
-          ),
-          changedValue: description,
-        );
+  }) : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for pubspec changes'),
+       super._(
+         component: DocComponent.meta(name: title, description: description, filePath: filePath),
+         changedValue: description,
+       );
 
   static const Set<ApiChangeOperation> _allowedOperations = {
     ApiChangeOperation.dependencyVersionChange,
@@ -185,10 +176,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.dependencyAdded({
-    required String dependencyName,
-    required String? version,
-  }) {
+  factory MetaApiChange.dependencyAdded({required String dependencyName, required String? version}) {
     return MetaApiChange(
       operation: ApiChangeOperation.dependencyAddition,
       title: "dependency `$dependencyName`",
@@ -196,9 +184,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.dependencyRemoved({
-    required String dependencyName,
-  }) {
+  factory MetaApiChange.dependencyRemoved({required String dependencyName}) {
     return MetaApiChange(
       operation: ApiChangeOperation.dependencyRemoval,
       title: "dependency `$dependencyName`",
@@ -206,10 +192,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minDartSdkVersionDecrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.minDartSdkVersionDecrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minDartSdkVersionDecrease,
       title: "Minimum Dart SDK version decreased",
@@ -217,10 +200,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minDartSdkVersionIncrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.minDartSdkVersionIncrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minDartSdkVersionIncrease,
       title: "Minimum Dart SDK version increased",
@@ -228,10 +208,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.maxDartSdkVersionDecrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.maxDartSdkVersionDecrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.maxDartSdkVersionDecrease,
       title: "Maximum Dart SDK version decreased",
@@ -239,10 +216,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.maxDartSdkVersionIncrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.maxDartSdkVersionIncrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.maxDartSdkVersionIncrease,
       title: "Maximum Dart SDK version increased",
@@ -250,10 +224,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minFlutterSdkVersionDecrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.minFlutterSdkVersionDecrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minFlutterSdkVersionDecrease,
       title: "Minimum Flutter SDK version decreased",
@@ -261,10 +232,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minFlutterSdkVersionIncrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.minFlutterSdkVersionIncrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minFlutterSdkVersionIncrease,
       title: "Minimum Flutter SDK version increased",
@@ -272,10 +240,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.maxFlutterSdkVersionDecrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.maxFlutterSdkVersionDecrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.maxFlutterSdkVersionDecrease,
       title: "Maximum Flutter SDK version decreased",
@@ -283,10 +248,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.maxFlutterSdkVersionIncrease({
-    required String version,
-    required String previousVersion,
-  }) {
+  factory MetaApiChange.maxFlutterSdkVersionIncrease({required String version, required String previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.maxFlutterSdkVersionIncrease,
       title: "Maximum Flutter SDK version increased",
@@ -294,10 +256,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minAndroidSdkVersionDecrease({
-    required int version,
-    required int previousVersion,
-  }) {
+  factory MetaApiChange.minAndroidSdkVersionDecrease({required int version, required int previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minAndroidSdkVersionDecrease,
       title: "Minimum Android SDK version decreased",
@@ -305,10 +264,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minAndroidSdkVersionIncrease({
-    required int version,
-    required int previousVersion,
-  }) {
+  factory MetaApiChange.minAndroidSdkVersionIncrease({required int version, required int previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minAndroidSdkVersionIncrease,
       title: "Minimum Android SDK version increased",
@@ -316,10 +272,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minIosSdkVersionDecrease({
-    required num version,
-    required num previousVersion,
-  }) {
+  factory MetaApiChange.minIosSdkVersionDecrease({required num version, required num previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minIosSdkVersionDecrease,
       title: "Minimum iOS SDK version decreased",
@@ -327,10 +280,7 @@ class MetaApiChange extends ApiChange {
     );
   }
 
-  factory MetaApiChange.minIosSdkVersionIncrease({
-    required num version,
-    required num previousVersion,
-  }) {
+  factory MetaApiChange.minIosSdkVersionIncrease({required num version, required num previousVersion}) {
     return MetaApiChange(
       operation: ApiChangeOperation.minIosSdkVersionIncrease,
       title: "Minimum iOS SDK version increased",
@@ -347,13 +297,9 @@ class MetaApiChange extends ApiChange {
 /// A change that belongs to a specific component.
 /// A component can be a class, mixin, interface or typedef.
 class ComponentApiChange extends ApiChange {
-  ComponentApiChange({
-    required super.component,
-    required super.operation,
-    super.annotation,
-    super.changedValue,
-  })  : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for component changes'),
-        super._();
+  ComponentApiChange({required super.component, required super.operation, super.annotation, super.changedValue})
+    : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for component changes'),
+      super._();
 
   static const Set<ApiChangeOperation> _allowedOperations = {
     ApiChangeOperation.addition,
@@ -388,8 +334,8 @@ class PropertyApiChange extends ApiChange {
     required this.property,
     super.annotation,
     super.changedValue,
-  })  : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for property changes'),
-        super._();
+  }) : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for property changes'),
+       super._();
 
   static const Set<ApiChangeOperation> _allowedOperations = {
     ApiChangeOperation.addition,
@@ -448,8 +394,8 @@ class MethodApiChange extends ApiChange {
     this.newType,
     super.annotation,
     super.changedValue,
-  })  : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for method changes'),
-        super._();
+  }) : assert(_allowedOperations.contains(operation), 'Operation $operation not allowed for method changes'),
+       super._();
 
   static const Set<ApiChangeOperation> _allowedOperations = {
     ApiChangeOperation.addition,
@@ -516,9 +462,11 @@ abstract class ParameterApiChange extends ApiChange {
     this.oldName,
     this.newType,
     super.annotation,
-  })  : assert(
-            _allowedParameterOperations.contains(operation), 'Operation $operation not allowed for parameter changes'),
-        super._();
+  }) : assert(
+         _allowedParameterOperations.contains(operation),
+         'Operation $operation not allowed for parameter changes',
+       ),
+       super._();
 
   static const Set<ApiChangeOperation> _allowedParameterOperations = {
     ApiChangeOperation.addition,
@@ -605,9 +553,11 @@ class ConstructorApiChange extends ApiChange {
     required this.constructor,
     super.annotation,
     super.changedValue,
-  })  : assert(
-            !_disallowedConstructorOperations.contains(operation), 'Operation $operation not allowed for constructors'),
-        super._();
+  }) : assert(
+         !_disallowedConstructorOperations.contains(operation),
+         'Operation $operation not allowed for constructors',
+       ),
+       super._();
 
   static const Set<ApiChangeOperation> _disallowedConstructorOperations = {
     ApiChangeOperation.mixinApplication,

--- a/lib/doc_comparator/api_change_formatter.dart
+++ b/lib/doc_comparator/api_change_formatter.dart
@@ -14,17 +14,11 @@ class ApiChangeFormatter {
   ApiChangeFormatter(
     this.changes, {
     this.markdownHeaderLevel = 1,
-    this.magnitudes = const {
-      ApiChangeMagnitude.major,
-      ApiChangeMagnitude.minor,
-      ApiChangeMagnitude.patch,
-    },
+    this.magnitudes = const {ApiChangeMagnitude.major, ApiChangeMagnitude.minor, ApiChangeMagnitude.patch},
     this.fileUrlBuilder,
   });
 
-  bool get hasRelevantChanges => changes.any(
-        (changes) => magnitudes.contains(changes.getMagnitude()),
-      );
+  bool get hasRelevantChanges => changes.any((changes) => magnitudes.contains(changes.getMagnitude()));
 
   String get highestMagnitudeText => _getHighestMagnitudeText(getHighestMagnitude(changes));
 
@@ -41,9 +35,7 @@ class ApiChangeFormatter {
       changelogBuffer.writeln(_getMagnitudeHeader(magnitude));
 
       // Group by component and process them in alphabetical order
-      final componentChanges = _groupByComponent(
-        changesByMagnitude[magnitude]!,
-      );
+      final componentChanges = _groupByComponent(changesByMagnitude[magnitude]!);
       final sortedComponents = componentChanges.keys.toList()..sort();
       for (final component in sortedComponents) {
         final firstChange = componentChanges[component]!.first;
@@ -51,8 +43,9 @@ class ApiChangeFormatter {
         final typeLabel = componentObj.type.name.replaceAll("Type", "").toLowerCase();
         final filePath = componentObj.filePath;
 
-        final linkTarget =
-            (fileUrlBuilder != null && filePath != null) ? fileUrlBuilder!(filePath) ?? filePath : filePath;
+        final linkTarget = (fileUrlBuilder != null && filePath != null)
+            ? fileUrlBuilder!(filePath) ?? filePath
+            : filePath;
 
         changelogBuffer.writeln();
         changelogBuffer.writeln(
@@ -363,31 +356,29 @@ extension ApiChangeFormattingHelpers on List<ApiChange> {
   }
 
   String _formatChanges() {
-    return map(
-      (change) {
-        var changes = '';
-        if (change is PropertyApiChange) {
-          changes = "`" + change.property.name + "`";
-        } else if (change is MethodApiChange) {
-          changes = "`" + change.method.name + "`";
-          if (change.operation == ApiChangeOperation.typeChange) {
-            changes = "`" + change.method.name + "` " + _formatTypeChange(change.method.returnType, change.newType!);
-          }
-        } else if (change is ConstructorApiChange) {
-          changes = "`" + change.constructor.name + "`";
-        } else if (change is ComponentApiChange) {
-          changes = "`" + change.component.name + "`";
-        } else if (change is ParameterApiChange) {
-          changes = _formatParam(change.parameter);
-          if (change.operation == ApiChangeOperation.renaming) {
-            changes = "`" + change.oldName! + "` → `" + change.parameter.name + "`";
-          } else if (change.operation == ApiChangeOperation.typeChange) {
-            changes = "`" + change.parameter.name + "` " + _formatTypeChange(change.parameter.type, change.newType!);
-          }
+    return map((change) {
+      var changes = '';
+      if (change is PropertyApiChange) {
+        changes = "`${change.property.name}`";
+      } else if (change is MethodApiChange) {
+        changes = "`${change.method.name}`";
+        if (change.operation == ApiChangeOperation.typeChange) {
+          changes = "`${change.method.name}` ${_formatTypeChange(change.method.returnType, change.newType!)}";
         }
-        return changes;
-      },
-    ).join(', ');
+      } else if (change is ConstructorApiChange) {
+        changes = "`${change.constructor.name}`";
+      } else if (change is ComponentApiChange) {
+        changes = "`${change.component.name}`";
+      } else if (change is ParameterApiChange) {
+        changes = _formatParam(change.parameter);
+        if (change.operation == ApiChangeOperation.renaming) {
+          changes = "`${change.oldName!}` → `${change.parameter.name}`";
+        } else if (change.operation == ApiChangeOperation.typeChange) {
+          changes = "`${change.parameter.name}` ${_formatTypeChange(change.parameter.type, change.newType!)}";
+        }
+      }
+      return changes;
+    }).join(', ');
   }
 
   String _formatParam(DocParameter parameter) {

--- a/lib/doc_comparator/apply_overrides.dart
+++ b/lib/doc_comparator/apply_overrides.dart
@@ -9,9 +9,7 @@ void applyMagnitudeOverrides(List<ApiChange> changes, ApiGuardConfig config) {
   for (final change in changes) {
     for (final override in config.magnitudeOverrides) {
       if (_matches(override, change)) {
-        final magnitude = ApiChangeMagnitude.values.firstWhereOrNull(
-          (e) => e.name == override.magnitude,
-        );
+        final magnitude = ApiChangeMagnitude.values.firstWhereOrNull((e) => e.name == override.magnitude);
         if (magnitude != null) {
           final originalMagnitude = change.getMagnitude();
           change.overrideMagnitude(magnitude);
@@ -66,9 +64,7 @@ bool _matchesSelection(OverrideSelection selection, _SelectionContext context) {
       if (!regex.hasMatch(context.name)) return false;
     } on FormatException catch (e) {
       // Provide a clearer error message when an invalid regex pattern is configured.
-      throw FormatException(
-        'Invalid namePattern regex "${selection.namePattern}": ${e.message}',
-      );
+      throw FormatException('Invalid namePattern regex "${selection.namePattern}": ${e.message}');
     }
   }
 

--- a/lib/doc_comparator/comparators/comparator_helpers.dart
+++ b/lib/doc_comparator/comparators/comparator_helpers.dart
@@ -26,7 +26,7 @@ void compareLists<T>({
     if (!newMap.containsKey(key)) {
       onRemoved(oldItem);
     } else {
-      onMatched(oldItem, newMap[key]!);
+      onMatched(oldItem, newMap[key] as T);
     }
   }
 

--- a/lib/doc_comparator/comparators/component_comparator.dart
+++ b/lib/doc_comparator/comparators/component_comparator.dart
@@ -11,14 +11,8 @@ extension DocComponentListApiChangesExt on List<DocComponent> {
       oldList: this,
       newList: newComponents,
       keyExtractor: (c) => c.name,
-      onRemoved: (c) => changes.add(ComponentApiChange(
-        component: c,
-        operation: ApiChangeOperation.removal,
-      )),
-      onAdded: (c) => changes.add(ComponentApiChange(
-        component: c,
-        operation: ApiChangeOperation.addition,
-      )),
+      onRemoved: (c) => changes.add(ComponentApiChange(component: c, operation: ApiChangeOperation.removal)),
+      onAdded: (c) => changes.add(ComponentApiChange(component: c, operation: ApiChangeOperation.addition)),
       onMatched: (oldC, newC) => changes.addAll(oldC.compareTo(newC)),
     );
 
@@ -31,93 +25,73 @@ extension DocComponentApiChangesExt on DocComponent {
     final changes = <ApiChange>[];
 
     if (aliasedType != newComponent.aliasedType) {
-      changes.add(
-        ComponentApiChange(
-          component: this,
-          operation: ApiChangeOperation.typeChange,
-        ),
-      );
+      changes.add(ComponentApiChange(component: this, operation: ApiChangeOperation.typeChange));
     }
 
     compareAnnotations(
       oldAnnotations: annotations,
       newAnnotations: newComponent.annotations,
-      onRemoved: (a) => changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.annotationRemoval,
-        annotation: a,
-      )),
-      onAdded: (a) => changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.annotationAddition,
-        annotation: a,
-      )),
+      onRemoved: (a) => changes.add(
+        ComponentApiChange(component: this, operation: ApiChangeOperation.annotationRemoval, annotation: a),
+      ),
+      onAdded: (a) => changes.add(
+        ComponentApiChange(component: this, operation: ApiChangeOperation.annotationAddition, annotation: a),
+      ),
     );
 
     final oldSuperClass = superClasses.firstOrNull;
     final newSuperClass = newComponent.superClasses.firstOrNull;
     if (oldSuperClass != newSuperClass) {
-      changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.superClassChange,
-        changedValue: '`${oldSuperClass ?? 'Object'}` → `${newSuperClass ?? 'Object'}`',
-      ));
+      changes.add(
+        ComponentApiChange(
+          component: this,
+          operation: ApiChangeOperation.superClassChange,
+          changedValue: '`${oldSuperClass ?? 'Object'}` → `${newSuperClass ?? 'Object'}`',
+        ),
+      );
     }
 
     compareLists<String>(
       oldList: interfaces,
       newList: newComponent.interfaces,
       keyExtractor: (i) => i,
-      onRemoved: (i) => changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.interfaceRemoval,
-        changedValue: i,
-      )),
-      onAdded: (i) => changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.interfaceImplementation,
-        changedValue: i,
-      )),
-      onMatched: (_, __) {},
+      onRemoved: (i) => changes.add(
+        ComponentApiChange(component: this, operation: ApiChangeOperation.interfaceRemoval, changedValue: i),
+      ),
+      onAdded: (i) => changes.add(
+        ComponentApiChange(component: this, operation: ApiChangeOperation.interfaceImplementation, changedValue: i),
+      ),
+      onMatched: (_, _) {},
     );
 
     compareLists<String>(
       oldList: mixins,
       newList: newComponent.mixins,
       keyExtractor: (m) => m,
-      onRemoved: (m) => changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.mixinRemoval,
-        changedValue: m,
-      )),
-      onAdded: (m) => changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.mixinApplication,
-        changedValue: m,
-      )),
-      onMatched: (_, __) {},
+      onRemoved: (m) =>
+          changes.add(ComponentApiChange(component: this, operation: ApiChangeOperation.mixinRemoval, changedValue: m)),
+      onAdded: (m) => changes.add(
+        ComponentApiChange(component: this, operation: ApiChangeOperation.mixinApplication, changedValue: m),
+      ),
+      onMatched: (_, _) {},
     );
 
     // Skip type parameter comparison for functions to prevent duplicate reports, as they are
     // already handled in MethodApiChangesExt.
     if (type != DocComponentType.functionType &&
         !const ListEquality().equals(typeParameters, newComponent.typeParameters)) {
-      changes.add(ComponentApiChange(
-        component: this,
-        operation: ApiChangeOperation.typeParametersChange,
-        changedValue: '`${typeParameters.join(', ')}` → `${newComponent.typeParameters.join(', ')}`',
-      ));
+      changes.add(
+        ComponentApiChange(
+          component: this,
+          operation: ApiChangeOperation.typeParametersChange,
+          changedValue: '`${typeParameters.join(', ')}` → `${newComponent.typeParameters.join(', ')}`',
+        ),
+      );
     }
 
-    changes.addAll(
-      constructors.compareTo(newComponent.constructors, component: this),
-    );
-    changes.addAll(
-      properties.compareTo(newComponent.properties, component: this),
-    );
-    changes.addAll(
-      methods.compareTo(newComponent.methods, component: this),
-    );
+    changes.addAll(constructors.compareTo(newComponent.constructors, component: this));
+    changes.addAll(properties.compareTo(newComponent.properties, component: this));
+    changes.addAll(methods.compareTo(newComponent.methods, component: this));
 
     return changes;
   }

--- a/lib/doc_comparator/comparators/member_comparator.dart
+++ b/lib/doc_comparator/comparators/member_comparator.dart
@@ -13,9 +13,14 @@ import 'comparator_helpers.dart';
 void _compareParameters({
   required List<DocParameter> oldParameters,
   required List<DocParameter> newParameters,
-  required void Function(DocParameter param, ApiChangeOperation op,
-          {String? oldName, String? annotation, DocType? newType})
-      onDiff,
+  required void Function(
+    DocParameter param,
+    ApiChangeOperation op, {
+    String? oldName,
+    String? annotation,
+    DocType? newType,
+  })
+  onDiff,
 }) {
   final oldParamsCopy = [...oldParameters];
   final newParamsCopy = [...newParameters];
@@ -76,17 +81,11 @@ void _compareParameters({
     }
 
     if (oldParam.required != newParam.required) {
-      onDiff(
-        oldParam,
-        oldParam.required ? ApiChangeOperation.becomingOptional : ApiChangeOperation.becomingRequired,
-      );
+      onDiff(oldParam, oldParam.required ? ApiChangeOperation.becomingOptional : ApiChangeOperation.becomingRequired);
     }
 
     if (oldParam.named != newParam.named) {
-      onDiff(
-        oldParam,
-        oldParam.named ? ApiChangeOperation.becomingPositional : ApiChangeOperation.becomingNamed,
-      );
+      onDiff(oldParam, oldParam.named ? ApiChangeOperation.becomingPositional : ApiChangeOperation.becomingNamed);
     } else if (!oldParam.named) {
       // Check for reordering (only for positional parameters)
       final oldIndex = oldPositional.indexOf(oldParam);
@@ -118,59 +117,66 @@ void _compareParameters({
 extension ConstructorApiChangesExt on DocConstructor {
   /// Compares [this] constructor with [newConstructor] and returns a list of
   /// [ApiChange]s that have been detected between the two constructors.
-  List<ApiChange> compareTo(
-    DocConstructor newConstructor, {
-    required DocComponent component,
-  }) {
+  List<ApiChange> compareTo(DocConstructor newConstructor, {required DocComponent component}) {
     final changes = <ApiChange>[];
 
     compareAnnotations(
       oldAnnotations: annotations,
       newAnnotations: newConstructor.annotations,
-      onRemoved: (a) => changes.add(ConstructorApiChange(
-        component: component,
-        constructor: this,
-        operation: ApiChangeOperation.annotationRemoval,
-        annotation: a,
-      )),
-      onAdded: (a) => changes.add(ConstructorApiChange(
-        component: component,
-        constructor: this,
-        operation: ApiChangeOperation.annotationAddition,
-        annotation: a,
-      )),
+      onRemoved: (a) => changes.add(
+        ConstructorApiChange(
+          component: component,
+          constructor: this,
+          operation: ApiChangeOperation.annotationRemoval,
+          annotation: a,
+        ),
+      ),
+      onAdded: (a) => changes.add(
+        ConstructorApiChange(
+          component: component,
+          constructor: this,
+          operation: ApiChangeOperation.annotationAddition,
+          annotation: a,
+        ),
+      ),
     );
 
     compareFeatures(
       oldFeatures: features,
       newFeatures: newConstructor.features,
-      onRemoved: (f) => changes.add(ConstructorApiChange(
-        component: component,
-        constructor: this,
-        operation: ApiChangeOperation.featureRemoval,
-        changedValue: f,
-      )),
-      onAdded: (f) => changes.add(ConstructorApiChange(
-        component: component,
-        constructor: this,
-        operation: ApiChangeOperation.featureAddition,
-        changedValue: f,
-      )),
+      onRemoved: (f) => changes.add(
+        ConstructorApiChange(
+          component: component,
+          constructor: this,
+          operation: ApiChangeOperation.featureRemoval,
+          changedValue: f,
+        ),
+      ),
+      onAdded: (f) => changes.add(
+        ConstructorApiChange(
+          component: component,
+          constructor: this,
+          operation: ApiChangeOperation.featureAddition,
+          changedValue: f,
+        ),
+      ),
     );
 
     _compareParameters(
       oldParameters: signature,
       newParameters: newConstructor.signature,
       onDiff: (param, op, {oldName, annotation, newType}) {
-        changes.add(ConstructorParameterApiChange(
-          component: component,
-          constructor: this,
-          operation: op,
-          parameter: param,
-          oldName: oldName,
-          newType: newType,
-          annotation: annotation,
-        ));
+        changes.add(
+          ConstructorParameterApiChange(
+            component: component,
+            constructor: this,
+            operation: op,
+            parameter: param,
+            oldName: oldName,
+            newType: newType,
+            annotation: annotation,
+          ),
+        );
       },
     );
 
@@ -181,26 +187,19 @@ extension ConstructorApiChangesExt on DocConstructor {
 extension ConstructorListApiChangesExt on List<DocConstructor> {
   /// Compares [this] list of constructors with [newConstructors] and returns a
   /// list of [ApiChange]s that have been detected between the two lists.
-  List<ApiChange> compareTo(
-    List<DocConstructor> newConstructors, {
-    required DocComponent component,
-  }) {
+  List<ApiChange> compareTo(List<DocConstructor> newConstructors, {required DocComponent component}) {
     final changes = <ApiChange>[];
 
     compareLists<DocConstructor>(
       oldList: this,
       newList: newConstructors,
       keyExtractor: (c) => c.name,
-      onRemoved: (c) => changes.add(ConstructorApiChange(
-        component: component,
-        constructor: c,
-        operation: ApiChangeOperation.removal,
-      )),
-      onAdded: (c) => changes.add(ConstructorApiChange(
-        component: component,
-        constructor: c,
-        operation: ApiChangeOperation.addition,
-      )),
+      onRemoved: (c) => changes.add(
+        ConstructorApiChange(component: component, constructor: c, operation: ApiChangeOperation.removal),
+      ),
+      onAdded: (c) => changes.add(
+        ConstructorApiChange(component: component, constructor: c, operation: ApiChangeOperation.addition),
+      ),
       onMatched: (oldC, newC) => changes.addAll(oldC.compareTo(newC, component: component)),
     );
 
@@ -211,67 +210,64 @@ extension ConstructorListApiChangesExt on List<DocConstructor> {
 extension PropertyListApiChangesExt on List<DocProperty> {
   /// Compares [this] list of properties with [newProperties] and returns a list
   /// of [ApiChange]s that have been detected between the two lists.
-  List<ApiChange> compareTo(
-    List<DocProperty> newProperties, {
-    required DocComponent component,
-  }) {
+  List<ApiChange> compareTo(List<DocProperty> newProperties, {required DocComponent component}) {
     final changes = <ApiChange>[];
 
     compareLists<DocProperty>(
       oldList: this,
       newList: newProperties,
       keyExtractor: (p) => p.name,
-      onRemoved: (p) => changes.add(PropertyApiChange(
-        component: component,
-        property: p,
-        operation: ApiChangeOperation.removal,
-      )),
-      onAdded: (p) => changes.add(PropertyApiChange(
-        component: component,
-        property: p,
-        operation: ApiChangeOperation.addition,
-      )),
+      onRemoved: (p) =>
+          changes.add(PropertyApiChange(component: component, property: p, operation: ApiChangeOperation.removal)),
+      onAdded: (p) =>
+          changes.add(PropertyApiChange(component: component, property: p, operation: ApiChangeOperation.addition)),
       onMatched: (oldP, newP) {
         if (oldP.type != newP.type) {
-          changes.add(PropertyApiChange(
-            component: component,
-            property: oldP,
-            operation: ApiChangeOperation.typeChange,
-          ));
+          changes.add(
+            PropertyApiChange(component: component, property: oldP, operation: ApiChangeOperation.typeChange),
+          );
         }
 
         compareFeatures(
           oldFeatures: oldP.features,
           newFeatures: newP.features,
-          onRemoved: (f) => changes.add(PropertyApiChange(
-            component: component,
-            property: oldP,
-            operation: ApiChangeOperation.featureRemoval,
-            changedValue: f,
-          )),
-          onAdded: (f) => changes.add(PropertyApiChange(
-            component: component,
-            property: oldP,
-            operation: ApiChangeOperation.featureAddition,
-            changedValue: f,
-          )),
+          onRemoved: (f) => changes.add(
+            PropertyApiChange(
+              component: component,
+              property: oldP,
+              operation: ApiChangeOperation.featureRemoval,
+              changedValue: f,
+            ),
+          ),
+          onAdded: (f) => changes.add(
+            PropertyApiChange(
+              component: component,
+              property: oldP,
+              operation: ApiChangeOperation.featureAddition,
+              changedValue: f,
+            ),
+          ),
         );
 
         compareAnnotations(
           oldAnnotations: oldP.annotations,
           newAnnotations: newP.annotations,
-          onRemoved: (a) => changes.add(PropertyApiChange(
-            component: component,
-            property: oldP,
-            operation: ApiChangeOperation.annotationRemoval,
-            annotation: a,
-          )),
-          onAdded: (a) => changes.add(PropertyApiChange(
-            component: component,
-            property: oldP,
-            operation: ApiChangeOperation.annotationAddition,
-            annotation: a,
-          )),
+          onRemoved: (a) => changes.add(
+            PropertyApiChange(
+              component: component,
+              property: oldP,
+              operation: ApiChangeOperation.annotationRemoval,
+              annotation: a,
+            ),
+          ),
+          onAdded: (a) => changes.add(
+            PropertyApiChange(
+              component: component,
+              property: oldP,
+              operation: ApiChangeOperation.annotationAddition,
+              annotation: a,
+            ),
+          ),
         );
       },
     );
@@ -283,26 +279,17 @@ extension PropertyListApiChangesExt on List<DocProperty> {
 extension MethodListApiChangesExt on List<DocMethod> {
   /// Compares [this] list of methods with [newMethods] and returns a list
   /// of [ApiChange]s that have been detected between the two lists.
-  List<ApiChange> compareTo(
-    List<DocMethod> newMethods, {
-    required DocComponent component,
-  }) {
+  List<ApiChange> compareTo(List<DocMethod> newMethods, {required DocComponent component}) {
     final changes = <ApiChange>[];
 
     compareLists<DocMethod>(
       oldList: this,
       newList: newMethods,
       keyExtractor: (m) => m.name,
-      onRemoved: (m) => changes.add(MethodApiChange(
-        component: component,
-        method: m,
-        operation: ApiChangeOperation.removal,
-      )),
-      onAdded: (m) => changes.add(MethodApiChange(
-        component: component,
-        method: m,
-        operation: ApiChangeOperation.addition,
-      )),
+      onRemoved: (m) =>
+          changes.add(MethodApiChange(component: component, method: m, operation: ApiChangeOperation.removal)),
+      onAdded: (m) =>
+          changes.add(MethodApiChange(component: component, method: m, operation: ApiChangeOperation.addition)),
       onMatched: (oldM, newM) => changes.addAll(oldM.compareTo(newM, component: component)),
     );
 
@@ -313,77 +300,88 @@ extension MethodListApiChangesExt on List<DocMethod> {
 extension MethodApiChangesExt on DocMethod {
   /// Compares [this] method with [newMethod] and returns a list of
   /// [ApiChange]s that have been detected between the two methods.
-  List<ApiChange> compareTo(
-    DocMethod newMethod, {
-    required DocComponent component,
-  }) {
+  List<ApiChange> compareTo(DocMethod newMethod, {required DocComponent component}) {
     final changes = <ApiChange>[];
 
     if (returnType != newMethod.returnType) {
-      changes.add(MethodApiChange(
-        component: component,
-        method: this,
-        operation: ApiChangeOperation.typeChange,
-        newType: newMethod.returnType,
-      ));
+      changes.add(
+        MethodApiChange(
+          component: component,
+          method: this,
+          operation: ApiChangeOperation.typeChange,
+          newType: newMethod.returnType,
+        ),
+      );
     }
 
     if (!const ListEquality().equals(typeParameters, newMethod.typeParameters)) {
-      changes.add(MethodApiChange(
-        component: component,
-        method: this,
-        operation: ApiChangeOperation.typeParametersChange,
-        changedValue: '`${typeParameters.join(', ')}` → `${newMethod.typeParameters.join(', ')}`',
-      ));
+      changes.add(
+        MethodApiChange(
+          component: component,
+          method: this,
+          operation: ApiChangeOperation.typeParametersChange,
+          changedValue: '`${typeParameters.join(', ')}` → `${newMethod.typeParameters.join(', ')}`',
+        ),
+      );
     }
 
     compareFeatures(
       oldFeatures: features,
       newFeatures: newMethod.features,
-      onRemoved: (f) => changes.add(MethodApiChange(
-        component: component,
-        method: this,
-        operation: ApiChangeOperation.featureRemoval,
-        changedValue: f,
-      )),
-      onAdded: (f) => changes.add(MethodApiChange(
-        component: component,
-        method: this,
-        operation: ApiChangeOperation.featureAddition,
-        changedValue: f,
-      )),
+      onRemoved: (f) => changes.add(
+        MethodApiChange(
+          component: component,
+          method: this,
+          operation: ApiChangeOperation.featureRemoval,
+          changedValue: f,
+        ),
+      ),
+      onAdded: (f) => changes.add(
+        MethodApiChange(
+          component: component,
+          method: this,
+          operation: ApiChangeOperation.featureAddition,
+          changedValue: f,
+        ),
+      ),
     );
 
     compareAnnotations(
       oldAnnotations: annotations,
       newAnnotations: newMethod.annotations,
-      onRemoved: (a) => changes.add(MethodApiChange(
-        component: component,
-        method: this,
-        operation: ApiChangeOperation.annotationRemoval,
-        annotation: a,
-      )),
-      onAdded: (a) => changes.add(MethodApiChange(
-        component: component,
-        method: this,
-        operation: ApiChangeOperation.annotationAddition,
-        annotation: a,
-      )),
+      onRemoved: (a) => changes.add(
+        MethodApiChange(
+          component: component,
+          method: this,
+          operation: ApiChangeOperation.annotationRemoval,
+          annotation: a,
+        ),
+      ),
+      onAdded: (a) => changes.add(
+        MethodApiChange(
+          component: component,
+          method: this,
+          operation: ApiChangeOperation.annotationAddition,
+          annotation: a,
+        ),
+      ),
     );
 
     _compareParameters(
       oldParameters: signature,
       newParameters: newMethod.signature,
       onDiff: (param, op, {oldName, annotation, newType}) {
-        changes.add(MethodParameterApiChange(
-          component: component,
-          method: this,
-          operation: op,
-          parameter: param,
-          oldName: oldName,
-          newType: newType,
-          annotation: annotation,
-        ));
+        changes.add(
+          MethodParameterApiChange(
+            component: component,
+            method: this,
+            operation: op,
+            parameter: param,
+            oldName: oldName,
+            newType: newType,
+            annotation: annotation,
+          ),
+        );
       },
     );
 

--- a/lib/doc_comparator/comparators/metadata_comparator.dart
+++ b/lib/doc_comparator/comparators/metadata_comparator.dart
@@ -11,17 +11,17 @@ extension MetadataComparator on PackageMetadata {
       newList: newMeta.dependencies,
       keyExtractor: (d) => d.packageName,
       onRemoved: (d) => changes.add(MetaApiChange.dependencyRemoved(dependencyName: d.packageName)),
-      onAdded: (d) => changes.add(MetaApiChange.dependencyAdded(
-        dependencyName: d.packageName,
-        version: d.packageVersion,
-      )),
+      onAdded: (d) =>
+          changes.add(MetaApiChange.dependencyAdded(dependencyName: d.packageName, version: d.packageVersion)),
       onMatched: (oldD, newD) {
         if (oldD.packageVersion != newD.packageVersion) {
-          changes.add(MetaApiChange.dependencyVersionChange(
-            dependencyName: oldD.packageName,
-            version: newD.packageVersion,
-            previousVersion: oldD.packageVersion,
-          ));
+          changes.add(
+            MetaApiChange.dependencyVersionChange(
+              dependencyName: oldD.packageName,
+              version: newD.packageVersion,
+              previousVersion: oldD.packageVersion,
+            ),
+          );
         }
       },
     );
@@ -67,28 +67,16 @@ extension MetadataComparator on PackageMetadata {
       if (baseMin != newMin) {
         if (baseMin == null && newMin != null) {
           // No previous constraint, now there is one
-          changes.add(MetaApiChange.minAndroidSdkVersionIncrease(
-            version: newMin,
-            previousVersion: 0,
-          ));
+          changes.add(MetaApiChange.minAndroidSdkVersionIncrease(version: newMin, previousVersion: 0));
         } else if (baseMin != null && newMin == null) {
           // Had a constraint, now removed
-          changes.add(MetaApiChange.minAndroidSdkVersionDecrease(
-            version: 0,
-            previousVersion: baseMin,
-          ));
+          changes.add(MetaApiChange.minAndroidSdkVersionDecrease(version: 0, previousVersion: baseMin));
         } else if (baseMin != null && newMin != null) {
           // Compare versions
           if (newMin > baseMin) {
-            changes.add(MetaApiChange.minAndroidSdkVersionIncrease(
-              version: newMin,
-              previousVersion: baseMin,
-            ));
+            changes.add(MetaApiChange.minAndroidSdkVersionIncrease(version: newMin, previousVersion: baseMin));
           } else if (newMin < baseMin) {
-            changes.add(MetaApiChange.minAndroidSdkVersionDecrease(
-              version: newMin,
-              previousVersion: baseMin,
-            ));
+            changes.add(MetaApiChange.minAndroidSdkVersionDecrease(version: newMin, previousVersion: baseMin));
           }
         }
       }
@@ -102,28 +90,16 @@ extension MetadataComparator on PackageMetadata {
       if (baseMin != newMin) {
         if (baseMin == null && newMin != null) {
           // No previous constraint, now there is one
-          changes.add(MetaApiChange.minIosSdkVersionIncrease(
-            version: newMin,
-            previousVersion: 0,
-          ));
+          changes.add(MetaApiChange.minIosSdkVersionIncrease(version: newMin, previousVersion: 0));
         } else if (baseMin != null && newMin == null) {
           // Had a constraint, now removed
-          changes.add(MetaApiChange.minIosSdkVersionDecrease(
-            version: 0,
-            previousVersion: baseMin,
-          ));
+          changes.add(MetaApiChange.minIosSdkVersionDecrease(version: 0, previousVersion: baseMin));
         } else if (baseMin != null && newMin != null) {
           // Compare versions
           if (newMin > baseMin) {
-            changes.add(MetaApiChange.minIosSdkVersionIncrease(
-              version: newMin,
-              previousVersion: baseMin,
-            ));
+            changes.add(MetaApiChange.minIosSdkVersionIncrease(version: newMin, previousVersion: baseMin));
           } else if (newMin < baseMin) {
-            changes.add(MetaApiChange.minIosSdkVersionDecrease(
-              version: newMin,
-              previousVersion: baseMin,
-            ));
+            changes.add(MetaApiChange.minIosSdkVersionDecrease(version: newMin, previousVersion: baseMin));
           }
         }
       }

--- a/lib/doc_comparator/doc_comparator.dart
+++ b/lib/doc_comparator/doc_comparator.dart
@@ -20,9 +20,7 @@ Future<List<ApiChange>> compare({
   final baseApi = await getRef(ref: baseRef, dartRoot: dartRoot, gitRoot: gitRoot, cache: cache);
   final newApi = await getRef(ref: newRef, dartRoot: dartRoot, gitRoot: gitRoot, cache: cache);
 
-  final apiChanges = baseApi.components.compareTo(
-    newApi.components,
-  );
+  final apiChanges = baseApi.components.compareTo(newApi.components);
 
   apiChanges.addAll(baseApi.metadata.compareTo(newApi.metadata));
 

--- a/lib/doc_comparator/doc_comparator_command.dart
+++ b/lib/doc_comparator/doc_comparator_command.dart
@@ -32,14 +32,8 @@ class DocComparatorCommand extends Command
       defaultsTo: ['major', 'minor', 'patch'],
       allowed: ['major', 'minor', 'patch'],
     );
-    argParser.addOption(
-      'out',
-      help: 'Write the comparison results to a file',
-    );
-    argParser.addOption(
-      'base-url',
-      help: 'Base URL for file links (e.g. https://github.com/org/repo/blob/v1.0.0)',
-    );
+    argParser.addOption('out', help: 'Write the comparison results to a file');
+    argParser.addOption('base-url', help: 'Base URL for file links (e.g. https://github.com/org/repo/blob/v1.0.0)');
   }
 
   String? get out {
@@ -53,9 +47,7 @@ class DocComparatorCommand extends Command
   Set<ApiChangeMagnitude> get magnitudes {
     final magnitudes = argResults?['magnitudes'] as List<String>;
     return magnitudes
-        .map((e) => ApiChangeMagnitude.values.firstWhereOrNull(
-              (element) => element.toString().contains(e),
-            ))
+        .map((e) => ApiChangeMagnitude.values.firstWhereOrNull((element) => element.toString().contains(e)))
         .whereType<ApiChangeMagnitude>()
         .toSet();
   }
@@ -74,10 +66,7 @@ class DocComparatorCommand extends Command
     final config = ApiGuardConfig.load(root);
     applyMagnitudeOverrides(changes, config);
 
-    final formatter = ApiChangeFormatter(
-      changes,
-      magnitudes: magnitudes,
-    );
+    final formatter = ApiChangeFormatter(changes, magnitudes: magnitudes);
 
     if (!formatter.hasRelevantChanges) {
       logger.info('No relevant changes detected');

--- a/lib/doc_comparator/get_ref.dart
+++ b/lib/doc_comparator/get_ref.dart
@@ -30,11 +30,7 @@ Future<PackageApi> getRef({
 
     if (cacheInstance.hasApiFileForRef(repoPath, ref, dartRelativePath)) {
       logger.success('Using cached API documentation for $ref');
-      final cachedContent = await cacheInstance.retrieveApiFile(
-        repoPath,
-        ref,
-        dartRelativePath,
-      );
+      final cachedContent = await cacheInstance.retrieveApiFile(repoPath, ref, dartRelativePath);
       if (cachedContent != null) {
         return parsePackageApiFile(cachedContent);
       }
@@ -46,11 +42,5 @@ Future<PackageApi> getRef({
   }
 
   // Generate the API documentation for the ref
-  return generateDocs(
-    gitRef: ref,
-    out: null,
-    dartRoot: dartRoot,
-    gitRoot: gitRoot,
-    shouldCache: cache,
-  );
+  return generateDocs(gitRef: ref, out: null, dartRoot: dartRoot, gitRoot: gitRoot, shouldCache: cache);
 }

--- a/lib/doc_comparator/parse_doc_file.dart
+++ b/lib/doc_comparator/parse_doc_file.dart
@@ -6,10 +6,7 @@ PackageApi parsePackageApiFile(String content) {
   final json = jsonDecode(content);
   if (json is List) {
     // Handle legacy format (List<DocComponent>)
-    return PackageApi(
-      metadata: PackageMetadata(),
-      components: json.map((e) => DocComponent.fromJson(e)).toList(),
-    );
+    return PackageApi(metadata: PackageMetadata(), components: json.map((e) => DocComponent.fromJson(e)).toList());
   }
   return PackageApi.fromJson(json);
 }

--- a/lib/doc_generator/cache.dart
+++ b/lib/doc_generator/cache.dart
@@ -45,12 +45,7 @@ class Cache {
   }
 
   /// Stores API documentation for a specific git ref and dart root
-  Future<void> storeApiFile(
-    String repoPath,
-    String ref,
-    String dartRelativePath,
-    String content,
-  ) async {
+  Future<void> storeApiFile(String repoPath, String ref, String dartRelativePath, String content) async {
     final repoCacheDir = getRepositoryCacheDir(repoPath);
     if (!repoCacheDir.existsSync()) {
       repoCacheDir.createSync(recursive: true);
@@ -66,11 +61,7 @@ class Cache {
   }
 
   /// Retrieves API documentation for a specific git ref and dart root
-  Future<String?> retrieveApiFile(
-    String repoPath,
-    String ref,
-    String dartRelativePath,
-  ) async {
+  Future<String?> retrieveApiFile(String repoPath, String ref, String dartRelativePath) async {
     final apiFile = getApiFileForRef(repoPath, ref, dartRelativePath);
     if (apiFile.existsSync()) {
       return await apiFile.readAsString();

--- a/lib/doc_generator/detect_exclusions.dart
+++ b/lib/doc_generator/detect_exclusions.dart
@@ -77,9 +77,7 @@ Set<String> detectExclusionsFromConfig(String root) {
     final exclusions = <String>{};
     for (final item in apiGuard) {
       if (item is String) {
-        exclusions.addAll(
-          Glob(item).listSync().map((e) => normalize(e.path)),
-        );
+        exclusions.addAll(Glob(item).listSync().map((e) => normalize(e.path)));
       }
     }
     return exclusions;

--- a/lib/doc_generator/detect_target_files.dart
+++ b/lib/doc_generator/detect_target_files.dart
@@ -44,16 +44,14 @@ Set<String> detectTargetFiles(String root) {
 
   if (include is YamlList) {
     for (final item in include) {
-      targetFiles.addAll(
-          Glob(item).listSync(root: root).map((e) => normalize(e.path)));
+      targetFiles.addAll(Glob(item).listSync(root: root).map((e) => normalize(e.path)));
     }
   }
 
   // Include parameter is a single string
 
   if (include is String) {
-    targetFiles.addAll(
-        Glob(include).listSync(root: root).map((e) => normalize(e.path)));
+    targetFiles.addAll(Glob(include).listSync(root: root).map((e) => normalize(e.path)));
   }
 
   return targetFiles;

--- a/lib/doc_generator/doc_generator.dart
+++ b/lib/doc_generator/doc_generator.dart
@@ -138,12 +138,9 @@ Future<PackageApi> generateDocs({
       }
 
       logger.info(
-          'Detected ${isFlutterProject ? "Flutter" : "Dart"} project, running $command ${args.join(' ')} in $packagePath');
-      final result = Process.runSync(
-        command,
-        args,
-        workingDirectory: packagePath,
+        'Detected ${isFlutterProject ? "Flutter" : "Dart"} project, running $command ${args.join(' ')} in $packagePath',
       );
+      final result = Process.runSync(command, args, workingDirectory: packagePath);
       if (result.exitCode != 0) {
         logger.err('Failed to run $command ${args.join(' ')}: ${result.stderr} in $packagePath');
         if (result.stdout.toString().isNotEmpty) {
@@ -162,11 +159,7 @@ Future<PackageApi> generateDocs({
   if (shouldCache) {
     if (cache.hasApiFileForRef(repoPath, effectiveRef, dartRelativePath)) {
       logger.success('Using cached API documentation for $effectiveRef');
-      final cachedContent = await cache.retrieveApiFile(
-        repoPath,
-        effectiveRef,
-        dartRelativePath,
-      );
+      final cachedContent = await cache.retrieveApiFile(repoPath, effectiveRef, dartRelativePath);
       if (cachedContent != null) {
         logger.success('Using cached API documentation for $effectiveRef in $dartRelativePath');
 
@@ -229,8 +222,9 @@ Future<PackageApi> generateDocs({
       // We do this only if the include configuration is the default one
       final isDefaultInclude = config.include.length == 1 && config.include.contains('lib/**.dart');
 
-      final mainLibrary =
-          normalize(absolute(join(analysisDartRoot.path, 'lib', '${packageMetadata.packageName}.dart')));
+      final mainLibrary = normalize(
+        absolute(join(analysisDartRoot.path, 'lib', '${packageMetadata.packageName}.dart')),
+      );
 
       if (isDefaultInclude && File(mainLibrary).existsSync()) {
         useRecursiveAnalysis = true;
@@ -286,10 +280,7 @@ Future<PackageApi> generateDocs({
         // Ignore resolution errors, fallback to uri
       }
 
-      final visitor = DocVisitor(
-        filePath: filePath,
-        entryPoint: entryPoint,
-      );
+      final visitor = DocVisitor(filePath: filePath, entryPoint: entryPoint);
       library.accept(visitor);
       classes.addAll(visitor.components);
 
@@ -315,21 +306,12 @@ Future<PackageApi> generateDocs({
         }
 
         if (useRecursiveAnalysis) {
-          visitLibraryRecursive(
-            libraryResult.element,
-            relative(file, from: normalizedRoot),
-          );
+          visitLibraryRecursive(libraryResult.element, relative(file, from: normalizedRoot));
         } else {
           // Legacy / Glob mode: non-recursive, just the file
           final visitor = DocVisitor(
-            filePath: relative(
-              file,
-              from: contextCollection.contextFor(file).contextRoot.root.path,
-            ),
-            entryPoint: relative(
-              file,
-              from: contextCollection.contextFor(file).contextRoot.root.path,
-            ),
+            filePath: relative(file, from: contextCollection.contextFor(file).contextRoot.root.path),
+            entryPoint: relative(file, from: contextCollection.contextFor(file).contextRoot.root.path),
           );
           libraryResult.element.accept(visitor);
           classes.addAll(visitor.components);
@@ -338,25 +320,18 @@ Future<PackageApi> generateDocs({
         logger.err('Error analyzing file $file: $e');
       }
       if (!useRecursiveAnalysis) {
-        progress.update(
-          "Analyzed $file [${filesToAnalyze.toList().indexOf(file) + 1}/${filesToAnalyze.length}]",
-        );
+        progress.update("Analyzed $file [${filesToAnalyze.toList().indexOf(file) + 1}/${filesToAnalyze.length}]");
       }
     }
 
     progress.complete();
 
-    logger.success(
-      'Found ${classes.length} classes: ${classes.map((e) => e.name).join(', ')}',
-    );
+    logger.success('Found ${classes.length} classes: ${classes.map((e) => e.name).join(', ')}');
     contextCollection.dispose();
 
     final outputProgress = logger.progress("Generating output");
 
-    final packageApi = PackageApi(
-      metadata: packageMetadata,
-      components: classes,
-    );
+    final packageApi = PackageApi(metadata: packageMetadata, components: classes);
 
     // Generate output
     final output = const JsonEncoder.withIndent('  ').convert(packageApi);

--- a/lib/doc_generator/doc_generator.dart
+++ b/lib/doc_generator/doc_generator.dart
@@ -1,12 +1,10 @@
-// ignore_for_file: experimental_member_use
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:mtrust_api_guard/bootstrap.dart';
 import 'package:mtrust_api_guard/doc_comparator/parse_doc_file.dart';
 import 'package:mtrust_api_guard/doc_generator/cache.dart';
@@ -257,7 +255,7 @@ Future<PackageApi> generateDocs({
     final normalizedRoot = normalize(absolute(analysisDartRoot.path));
 
     // Recursive visitor function
-    void visitLibraryRecursive(LibraryElement2 library, String entryPoint) {
+    void visitLibraryRecursive(LibraryElement library, String entryPoint) {
       if (visitedLibraries.contains(library.uri.toString())) return;
       visitedLibraries.add(library.uri.toString());
 
@@ -292,10 +290,10 @@ Future<PackageApi> generateDocs({
         filePath: filePath,
         entryPoint: entryPoint,
       );
-      library.accept2(visitor);
+      library.accept(visitor);
       classes.addAll(visitor.components);
 
-      for (final exported in library.exportedLibraries2) {
+      for (final exported in library.exportedLibraries) {
         // Only follow re-exports from within the host package.
         // External packages (e.g. patrol, flutter) may themselves re-export
         // large transitive graphs (vector_math, dart:ui, etc.) — we don't
@@ -318,7 +316,7 @@ Future<PackageApi> generateDocs({
 
         if (useRecursiveAnalysis) {
           visitLibraryRecursive(
-            libraryResult.element2,
+            libraryResult.element,
             relative(file, from: normalizedRoot),
           );
         } else {
@@ -333,7 +331,7 @@ Future<PackageApi> generateDocs({
               from: contextCollection.contextFor(file).contextRoot.root.path,
             ),
           );
-          libraryResult.element2.accept2(visitor);
+          libraryResult.element.accept(visitor);
           classes.addAll(visitor.components);
         }
       } catch (e) {

--- a/lib/doc_generator/doc_generator.dart
+++ b/lib/doc_generator/doc_generator.dart
@@ -10,6 +10,7 @@ import 'package:mtrust_api_guard/doc_comparator/parse_doc_file.dart';
 import 'package:mtrust_api_guard/doc_generator/cache.dart';
 import 'package:mtrust_api_guard/doc_generator/doc_visitor.dart';
 import 'package:mtrust_api_guard/doc_generator/git_utils.dart';
+import 'package:mtrust_api_guard/doc_generator/get_sdk_path.dart';
 import 'package:mtrust_api_guard/logger.dart';
 import 'package:mtrust_api_guard/doc_generator/pubspec_analyzer.dart';
 import 'package:mtrust_api_guard/mtrust_api_guard.dart';
@@ -242,6 +243,7 @@ Future<PackageApi> generateDocs({
     final contextCollection = AnalysisContextCollection(
       includedPaths: [normalize(absolute(analysisDartRoot.path))],
       excludedPaths: config.exclude.toList(),
+      sdkPath: getSdkPath(),
     );
 
     final progress = logger.progress("Analyzing dart files");

--- a/lib/doc_generator/doc_generator_command.dart
+++ b/lib/doc_generator/doc_generator_command.dart
@@ -28,10 +28,7 @@ class DocGeneratorCommand extends Command with ApiGuardCommandMixinWithRoot, Api
     }
 
     if (!argParser.hasOptionWithKey('out')) {
-      argParser.addOption(
-        'out',
-        help: 'Write the generated documentation to a file',
-      );
+      argParser.addOption('out', help: 'Write the generated documentation to a file');
     }
 
     return argParser;
@@ -57,12 +54,6 @@ class DocGeneratorCommand extends Command with ApiGuardCommandMixinWithRoot, Api
       logger.info(argParser.usage);
       return null;
     }
-    generateDocs(
-      gitRef: ref,
-      out: out,
-      dartRoot: root,
-      gitRoot: Directory.current,
-      shouldCache: cache,
-    );
+    generateDocs(gitRef: ref, out: out, dartRoot: root, gitRoot: Directory.current, shouldCache: cache);
   }
 }

--- a/lib/doc_generator/doc_visitor.dart
+++ b/lib/doc_generator/doc_visitor.dart
@@ -263,7 +263,7 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
         .map(
           (param) => DocParameter(
             description: _getDescription(param),
-            name: param.name!,
+            name: _parameterName(param),
             type: _getDocType(param.type),
             named: param.isNamed,
             required: param.isRequired,
@@ -272,6 +272,15 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
           ),
         )
         .toList();
+  }
+
+  /// Uses [FieldFormalParameterElement.privateName] when set so private field
+  /// formal parameters keep their declared name (e.g. `_internalId`).
+  String _parameterName(FormalParameterElement param) {
+    if (param is FieldFormalParameterElement) {
+      return param.privateName ?? param.name!;
+    }
+    return param.name!;
   }
 
   /// Extracts type parameters from an element.

--- a/lib/doc_generator/doc_visitor.dart
+++ b/lib/doc_generator/doc_visitor.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: experimental_member_use
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/visitor2.dart';
@@ -21,33 +19,33 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
 
   /// Visits a class element and extracts its documentation.
   @override
-  void visitClassElement(ClassElement2 element) {
+  void visitClassElement(ClassElement element) {
     final superTypeInfo = _getSuperTypeInfo(element);
 
     components.add(DocComponent(
-      name: element.name3!,
+      name: element.name!,
       filePath: filePath,
       entryPoint: entryPoint,
       description: _getDescription(element),
-      constructors: _mapConstructors(element.constructors2),
+      constructors: _mapConstructors(element.constructors),
       properties: _mapProperties(_collectFieldsWithInheritance(element)),
       methods: _mapMethods(_collectMethodsWithInheritance(element)),
       type: DocComponentType.classType,
       annotations: _getAnnotations(element),
       superClasses: superTypeInfo.superClasses,
       superClassPackages: superTypeInfo.superClassPackages,
-      interfaces: element.interfaces.map((e) => e.element3.name3!).toList(),
-      mixins: element.mixins.map((e) => e.element3.name3!).toList(),
-      typeParameters: _getTypeParameters(element.typeParameters2),
+      interfaces: element.interfaces.map((e) => e.element.name!).toList(),
+      mixins: element.mixins.map((e) => e.element.name!).toList(),
+      typeParameters: _getTypeParameters(element.typeParameters),
     ));
     super.visitClassElement(element);
   }
 
   /// Visits a mixin element and extracts its documentation.
   @override
-  void visitMixinElement(MixinElement2 element) {
+  void visitMixinElement(MixinElement element) {
     components.add(DocComponent(
-      name: element.name3!,
+      name: element.name!,
       filePath: filePath,
       description: _getDescription(element),
       constructors: [],
@@ -55,34 +53,34 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
       methods: _mapMethods(_collectMethodsWithInheritance(element)),
       type: DocComponentType.mixinType,
       annotations: _getAnnotations(element),
-      interfaces: element.interfaces.map((e) => e.element3.name3!).toList(),
-      typeParameters: _getTypeParameters(element.typeParameters2),
+      interfaces: element.interfaces.map((e) => e.element.name!).toList(),
+      typeParameters: _getTypeParameters(element.typeParameters),
     ));
     super.visitMixinElement(element);
   }
 
   /// Visits an enum element and extracts its documentation.
   @override
-  void visitEnumElement(EnumElement2 element) {
+  void visitEnumElement(EnumElement element) {
     components.add(DocComponent(
-      name: element.name3!,
+      name: element.name!,
       filePath: filePath,
       description: _getDescription(element),
-      constructors: _mapConstructors(element.constructors2),
-      properties: _mapProperties(element.fields2),
-      methods: _mapMethods(element.methods2),
+      constructors: _mapConstructors(element.constructors),
+      properties: _mapProperties(element.fields),
+      methods: _mapMethods(element.methods),
       type: DocComponentType.enumType,
       annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters2),
+      typeParameters: _getTypeParameters(element.typeParameters),
     ));
     super.visitEnumElement(element);
   }
 
   /// Visits a type alias element and extracts its documentation.
   @override
-  void visitTypeAliasElement(TypeAliasElement2 element) {
+  void visitTypeAliasElement(TypeAliasElement element) {
     components.add(DocComponent(
-      name: element.name3!,
+      name: element.name!,
       filePath: filePath,
       description: _getDescription(element),
       constructors: [],
@@ -91,25 +89,25 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
       type: DocComponentType.typedefType,
       aliasedType: element.aliasedType.toString(),
       annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters2),
+      typeParameters: _getTypeParameters(element.typeParameters),
     ));
     super.visitTypeAliasElement(element);
   }
 
   /// Visits an extension element and extracts its documentation.
   @override
-  void visitExtensionElement(ExtensionElement2 element) {
+  void visitExtensionElement(ExtensionElement element) {
     components.add(DocComponent(
-      name: element.name3 ?? 'extension',
+      name: element.name ?? 'extension',
       filePath: filePath,
       description: _getDescription(element),
       constructors: [],
-      properties: _mapProperties(element.fields2),
-      methods: _mapMethods(element.methods2),
+      properties: _mapProperties(element.fields),
+      methods: _mapMethods(element.methods),
       type: DocComponentType.extensionType,
       aliasedType: element.extendedType.toString(),
       annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters2),
+      typeParameters: _getTypeParameters(element.typeParameters),
     ));
     super.visitExtensionElement(element);
   }
@@ -118,14 +116,14 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
   @override
   void visitTopLevelFunctionElement(TopLevelFunctionElement element) {
     components.add(DocComponent(
-      name: element.name3!,
+      name: element.name!,
       filePath: filePath,
       description: _getDescription(element),
       constructors: [],
       properties: [],
       methods: [
         DocMethod(
-          name: element.name3!,
+          name: element.name!,
           returnType: _getDocType(element.returnType),
           description: _getDescription(element),
           signature: _mapParameters(element.formalParameters),
@@ -134,12 +132,12 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
             if (element.isExternal) "external",
           ],
           annotations: _getAnnotations(element),
-          typeParameters: _getTypeParameters(element.typeParameters2),
+          typeParameters: _getTypeParameters(element.typeParameters),
         )
       ],
       type: DocComponentType.functionType,
       annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters2),
+      typeParameters: _getTypeParameters(element.typeParameters),
     ));
     super.visitTopLevelFunctionElement(element);
   }
@@ -153,7 +151,7 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
 
   /// Extracts annotations from an element.
   List<String> _getAnnotations(dynamic element) {
-    final meta = element.metadata2;
+    final meta = element.metadata;
     if (meta is Metadata) {
       return meta.annotations.map((e) => e.toSource()).toList();
     }
@@ -161,48 +159,48 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
   }
 
   /// Collects all methods from the element and its supertypes, excluding [Object].
-  Iterable<MethodElement2> _collectMethodsWithInheritance(InterfaceElement2 element) {
-    final methodMap = <String, MethodElement2>{};
+  Iterable<MethodElement> _collectMethodsWithInheritance(InterfaceElement element) {
+    final methodMap = <String, MethodElement>{};
     for (final supertype in element.allSupertypes) {
       if (supertype.isDartCoreObject) continue;
-      for (final method in supertype.methods2) {
+      for (final method in supertype.methods) {
         if (!method.isStatic) {
-          methodMap[method.name3!] = method;
+          methodMap[method.name!] = method;
         }
       }
     }
-    for (final method in element.methods2) {
+    for (final method in element.methods) {
       // Filter out abstract methods in non-abstract classes (likely parser artifacts from invalid code)
-      if (element is ClassElement2 && !element.isAbstract && method.isAbstract) {
+      if (element is ClassElement && !element.isAbstract && method.isAbstract) {
         continue;
       }
-      methodMap[method.name3!] = method;
+      methodMap[method.name!] = method;
     }
     return methodMap.values;
   }
 
   /// Collects all fields from the element and its supertypes, excluding [Object].
-  Iterable<FieldElement2> _collectFieldsWithInheritance(InterfaceElement2 element) {
-    final propertyMap = <String, FieldElement2>{};
+  Iterable<FieldElement> _collectFieldsWithInheritance(InterfaceElement element) {
+    final propertyMap = <String, FieldElement>{};
     for (final supertype in element.allSupertypes) {
       if (supertype.isDartCoreObject) continue;
-      for (final field in supertype.element3.fields2) {
+      for (final field in supertype.element.fields) {
         if (!field.isStatic) {
-          propertyMap[field.name3!] = field;
+          propertyMap[field.name!] = field;
         }
       }
     }
-    for (final field in element.fields2) {
-      propertyMap[field.name3!] = field;
+    for (final field in element.fields) {
+      propertyMap[field.name!] = field;
     }
     return propertyMap.values;
   }
 
-  /// Maps a list of [ConstructorElement2] to [DocConstructor]s.
-  List<DocConstructor> _mapConstructors(List<ConstructorElement2> constructors) {
+  /// Maps a list of [ConstructorElement] to [DocConstructor]s.
+  List<DocConstructor> _mapConstructors(List<ConstructorElement> constructors) {
     return constructors
         .map((e) => DocConstructor(
-              name: e.name3!,
+              name: e.name!,
               signature: _mapParameters(e.formalParameters),
               features: [
                 if (e.isConst) "const",
@@ -214,11 +212,11 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
         .toList();
   }
 
-  /// Maps a list of [FieldElement2] to [DocProperty]s.
-  List<DocProperty> _mapProperties(Iterable<FieldElement2> fields) {
+  /// Maps a list of [FieldElement] to [DocProperty]s.
+  List<DocProperty> _mapProperties(Iterable<FieldElement> fields) {
     return fields
         .map((e) => DocProperty(
-              name: e.name3!,
+              name: e.name!,
               type: _getDocType(e.type),
               description: _getDescription(e),
               features: [
@@ -233,11 +231,11 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
         .toList();
   }
 
-  /// Maps a list of [MethodElement2] to [DocMethod]s.
-  List<DocMethod> _mapMethods(Iterable<MethodElement2> methods) {
+  /// Maps a list of [MethodElement] to [DocMethod]s.
+  List<DocMethod> _mapMethods(Iterable<MethodElement> methods) {
     return methods
         .map((e) => DocMethod(
-              name: e.name3!,
+              name: e.name!,
               returnType: _getDocType(e.returnType),
               description: _getDescription(e),
               signature: _mapParameters(e.formalParameters),
@@ -247,7 +245,7 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
                 if (e.isExternal) "external",
               ],
               annotations: _getAnnotations(e),
-              typeParameters: _getTypeParameters(e.typeParameters2),
+              typeParameters: _getTypeParameters(e.typeParameters),
             ))
         .toList();
   }
@@ -257,7 +255,7 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
     return parameters
         .map((param) => DocParameter(
               description: _getDescription(param),
-              name: param.name3!,
+              name: param.name!,
               type: _getDocType(param.type),
               named: param.isNamed,
               required: param.isRequired,
@@ -268,13 +266,13 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
   }
 
   /// Extracts type parameters from an element.
-  List<String> _getTypeParameters(List<TypeParameterElement2> typeParameters) {
+  List<String> _getTypeParameters(List<TypeParameterElement> typeParameters) {
     return typeParameters.map((e) {
       final bound = e.bound;
       if (bound != null) {
-        return '${e.name3} extends $bound';
+        return '${e.name} extends $bound';
       }
-      return e.name3!;
+      return e.name!;
     }).toList();
   }
 
@@ -282,7 +280,7 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
     final superTypes = <String>[];
     if (type is InterfaceType) {
       for (final superType in type.allSupertypes) {
-        superTypes.add(superType.element3.name3!);
+        superTypes.add(superType.element.name!);
       }
     }
     return DocType(
@@ -292,17 +290,17 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
     );
   }
 
-  ({List<String> superClasses, List<String> superClassPackages}) _getSuperTypeInfo(ClassElement2 element) {
+  ({List<String> superClasses, List<String> superClassPackages}) _getSuperTypeInfo(ClassElement element) {
     var superClasses = <String>[];
     var superClassPackages = <String>[];
     var current = element.supertype;
 
     while (current != null && !current.isDartCoreObject) {
       // 1. Add Class Name
-      superClasses.add(current.element3.name3!);
+      superClasses.add(current.element.name!);
 
       // 2. Add Package Name
-      final uri = current.element3.library2.uri;
+      final uri = current.element.library.uri;
       if (uri.isScheme('package')) {
         superClassPackages.add(uri.pathSegments.first);
       } else if (uri.isScheme('dart')) {

--- a/lib/doc_generator/doc_visitor.dart
+++ b/lib/doc_generator/doc_visitor.dart
@@ -22,123 +22,132 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
   void visitClassElement(ClassElement element) {
     final superTypeInfo = _getSuperTypeInfo(element);
 
-    components.add(DocComponent(
-      name: element.name!,
-      filePath: filePath,
-      entryPoint: entryPoint,
-      description: _getDescription(element),
-      constructors: _mapConstructors(element.constructors),
-      properties: _mapProperties(_collectFieldsWithInheritance(element)),
-      methods: _mapMethods(_collectMethodsWithInheritance(element)),
-      type: DocComponentType.classType,
-      annotations: _getAnnotations(element),
-      superClasses: superTypeInfo.superClasses,
-      superClassPackages: superTypeInfo.superClassPackages,
-      interfaces: element.interfaces.map((e) => e.element.name!).toList(),
-      mixins: element.mixins.map((e) => e.element.name!).toList(),
-      typeParameters: _getTypeParameters(element.typeParameters),
-    ));
+    components.add(
+      DocComponent(
+        name: element.name!,
+        filePath: filePath,
+        entryPoint: entryPoint,
+        description: _getDescription(element),
+        constructors: _mapConstructors(element.constructors),
+        properties: _mapProperties(_collectFieldsWithInheritance(element)),
+        methods: _mapMethods(_collectMethodsWithInheritance(element)),
+        type: DocComponentType.classType,
+        annotations: _getAnnotations(element),
+        superClasses: superTypeInfo.superClasses,
+        superClassPackages: superTypeInfo.superClassPackages,
+        interfaces: element.interfaces.map((e) => e.element.name!).toList(),
+        mixins: element.mixins.map((e) => e.element.name!).toList(),
+        typeParameters: _getTypeParameters(element.typeParameters),
+      ),
+    );
     super.visitClassElement(element);
   }
 
   /// Visits a mixin element and extracts its documentation.
   @override
   void visitMixinElement(MixinElement element) {
-    components.add(DocComponent(
-      name: element.name!,
-      filePath: filePath,
-      description: _getDescription(element),
-      constructors: [],
-      properties: _mapProperties(_collectFieldsWithInheritance(element)),
-      methods: _mapMethods(_collectMethodsWithInheritance(element)),
-      type: DocComponentType.mixinType,
-      annotations: _getAnnotations(element),
-      interfaces: element.interfaces.map((e) => e.element.name!).toList(),
-      typeParameters: _getTypeParameters(element.typeParameters),
-    ));
+    components.add(
+      DocComponent(
+        name: element.name!,
+        filePath: filePath,
+        description: _getDescription(element),
+        constructors: [],
+        properties: _mapProperties(_collectFieldsWithInheritance(element)),
+        methods: _mapMethods(_collectMethodsWithInheritance(element)),
+        type: DocComponentType.mixinType,
+        annotations: _getAnnotations(element),
+        interfaces: element.interfaces.map((e) => e.element.name!).toList(),
+        typeParameters: _getTypeParameters(element.typeParameters),
+      ),
+    );
     super.visitMixinElement(element);
   }
 
   /// Visits an enum element and extracts its documentation.
   @override
   void visitEnumElement(EnumElement element) {
-    components.add(DocComponent(
-      name: element.name!,
-      filePath: filePath,
-      description: _getDescription(element),
-      constructors: _mapConstructors(element.constructors),
-      properties: _mapProperties(element.fields),
-      methods: _mapMethods(element.methods),
-      type: DocComponentType.enumType,
-      annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters),
-    ));
+    components.add(
+      DocComponent(
+        name: element.name!,
+        filePath: filePath,
+        description: _getDescription(element),
+        constructors: _mapConstructors(element.constructors),
+        properties: _mapProperties(element.fields),
+        methods: _mapMethods(element.methods),
+        type: DocComponentType.enumType,
+        annotations: _getAnnotations(element),
+        typeParameters: _getTypeParameters(element.typeParameters),
+      ),
+    );
     super.visitEnumElement(element);
   }
 
   /// Visits a type alias element and extracts its documentation.
   @override
   void visitTypeAliasElement(TypeAliasElement element) {
-    components.add(DocComponent(
-      name: element.name!,
-      filePath: filePath,
-      description: _getDescription(element),
-      constructors: [],
-      properties: [],
-      methods: [],
-      type: DocComponentType.typedefType,
-      aliasedType: element.aliasedType.toString(),
-      annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters),
-    ));
+    components.add(
+      DocComponent(
+        name: element.name!,
+        filePath: filePath,
+        description: _getDescription(element),
+        constructors: [],
+        properties: [],
+        methods: [],
+        type: DocComponentType.typedefType,
+        aliasedType: element.aliasedType.toString(),
+        annotations: _getAnnotations(element),
+        typeParameters: _getTypeParameters(element.typeParameters),
+      ),
+    );
     super.visitTypeAliasElement(element);
   }
 
   /// Visits an extension element and extracts its documentation.
   @override
   void visitExtensionElement(ExtensionElement element) {
-    components.add(DocComponent(
-      name: element.name ?? 'extension',
-      filePath: filePath,
-      description: _getDescription(element),
-      constructors: [],
-      properties: _mapProperties(element.fields),
-      methods: _mapMethods(element.methods),
-      type: DocComponentType.extensionType,
-      aliasedType: element.extendedType.toString(),
-      annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters),
-    ));
+    components.add(
+      DocComponent(
+        name: element.name ?? 'extension',
+        filePath: filePath,
+        description: _getDescription(element),
+        constructors: [],
+        properties: _mapProperties(element.fields),
+        methods: _mapMethods(element.methods),
+        type: DocComponentType.extensionType,
+        aliasedType: element.extendedType.toString(),
+        annotations: _getAnnotations(element),
+        typeParameters: _getTypeParameters(element.typeParameters),
+      ),
+    );
     super.visitExtensionElement(element);
   }
 
   /// Visits a top-level function element and extracts its documentation.
   @override
   void visitTopLevelFunctionElement(TopLevelFunctionElement element) {
-    components.add(DocComponent(
-      name: element.name!,
-      filePath: filePath,
-      description: _getDescription(element),
-      constructors: [],
-      properties: [],
-      methods: [
-        DocMethod(
-          name: element.name!,
-          returnType: _getDocType(element.returnType),
-          description: _getDescription(element),
-          signature: _mapParameters(element.formalParameters),
-          features: [
-            if (element.isStatic) "static",
-            if (element.isExternal) "external",
-          ],
-          annotations: _getAnnotations(element),
-          typeParameters: _getTypeParameters(element.typeParameters),
-        )
-      ],
-      type: DocComponentType.functionType,
-      annotations: _getAnnotations(element),
-      typeParameters: _getTypeParameters(element.typeParameters),
-    ));
+    components.add(
+      DocComponent(
+        name: element.name!,
+        filePath: filePath,
+        description: _getDescription(element),
+        constructors: [],
+        properties: [],
+        methods: [
+          DocMethod(
+            name: element.name!,
+            returnType: _getDocType(element.returnType),
+            description: _getDescription(element),
+            signature: _mapParameters(element.formalParameters),
+            features: [if (element.isStatic) "static", if (element.isExternal) "external"],
+            annotations: _getAnnotations(element),
+            typeParameters: _getTypeParameters(element.typeParameters),
+          ),
+        ],
+        type: DocComponentType.functionType,
+        annotations: _getAnnotations(element),
+        typeParameters: _getTypeParameters(element.typeParameters),
+      ),
+    );
     super.visitTopLevelFunctionElement(element);
   }
 
@@ -199,69 +208,69 @@ class DocVisitor extends RecursiveElementVisitor2<void> {
   /// Maps a list of [ConstructorElement] to [DocConstructor]s.
   List<DocConstructor> _mapConstructors(List<ConstructorElement> constructors) {
     return constructors
-        .map((e) => DocConstructor(
-              name: e.name!,
-              signature: _mapParameters(e.formalParameters),
-              features: [
-                if (e.isConst) "const",
-                if (e.isFactory) "factory",
-                if (e.isExternal) "external",
-              ],
-              annotations: _getAnnotations(e),
-            ))
+        .map(
+          (e) => DocConstructor(
+            name: e.name!,
+            signature: _mapParameters(e.formalParameters),
+            features: [if (e.isConst) "const", if (e.isFactory) "factory", if (e.isExternal) "external"],
+            annotations: _getAnnotations(e),
+          ),
+        )
         .toList();
   }
 
   /// Maps a list of [FieldElement] to [DocProperty]s.
   List<DocProperty> _mapProperties(Iterable<FieldElement> fields) {
     return fields
-        .map((e) => DocProperty(
-              name: e.name!,
-              type: _getDocType(e.type),
-              description: _getDescription(e),
-              features: [
-                if (e.isStatic) "static",
-                if (e.isCovariant) "covariant",
-                if (e.isFinal) "final",
-                if (e.isConst) "const",
-                if (e.isLate) "late",
-              ],
-              annotations: _getAnnotations(e),
-            ))
+        .map(
+          (e) => DocProperty(
+            name: e.name!,
+            type: _getDocType(e.type),
+            description: _getDescription(e),
+            features: [
+              if (e.isStatic) "static",
+              if (e.isCovariant) "covariant",
+              if (e.isFinal) "final",
+              if (e.isConst) "const",
+              if (e.isLate) "late",
+            ],
+            annotations: _getAnnotations(e),
+          ),
+        )
         .toList();
   }
 
   /// Maps a list of [MethodElement] to [DocMethod]s.
   List<DocMethod> _mapMethods(Iterable<MethodElement> methods) {
     return methods
-        .map((e) => DocMethod(
-              name: e.name!,
-              returnType: _getDocType(e.returnType),
-              description: _getDescription(e),
-              signature: _mapParameters(e.formalParameters),
-              features: [
-                if (e.isStatic) "static",
-                if (e.isAbstract) "abstract",
-                if (e.isExternal) "external",
-              ],
-              annotations: _getAnnotations(e),
-              typeParameters: _getTypeParameters(e.typeParameters),
-            ))
+        .map(
+          (e) => DocMethod(
+            name: e.name!,
+            returnType: _getDocType(e.returnType),
+            description: _getDescription(e),
+            signature: _mapParameters(e.formalParameters),
+            features: [if (e.isStatic) "static", if (e.isAbstract) "abstract", if (e.isExternal) "external"],
+            annotations: _getAnnotations(e),
+            typeParameters: _getTypeParameters(e.typeParameters),
+          ),
+        )
         .toList();
   }
 
   /// Maps a list of [FormalParameterElement] to [DocParameter]s.
   List<DocParameter> _mapParameters(List<FormalParameterElement> parameters) {
     return parameters
-        .map((param) => DocParameter(
-              description: _getDescription(param),
-              name: param.name!,
-              type: _getDocType(param.type),
-              named: param.isNamed,
-              required: param.isRequired,
-              defaultValue: param.defaultValueCode,
-              annotations: _getAnnotations(param),
-            ))
+        .map(
+          (param) => DocParameter(
+            description: _getDescription(param),
+            name: param.name!,
+            type: _getDocType(param.type),
+            named: param.isNamed,
+            required: param.isRequired,
+            defaultValue: param.defaultValueCode,
+            annotations: _getAnnotations(param),
+          ),
+        )
         .toList();
   }
 

--- a/lib/doc_generator/get_sdk_path.dart
+++ b/lib/doc_generator/get_sdk_path.dart
@@ -1,7 +1,58 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
+/// Resolves the Dart SDK path for analyzer use, including when running as a compiled executable.
 String? getSdkPath() {
-  return Platform.environment['FLUTTER_ROOT'] != null
-      ? '${Platform.environment['FLUTTER_ROOT']}/bin/cache/dart-sdk'
-      : null;
+  final envSdk = Platform.environment['DART_SDK'];
+  if (envSdk != null && envSdk.isNotEmpty && Directory(envSdk).existsSync()) {
+    return p.normalize(envSdk);
+  }
+
+  final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+  if (flutterRoot != null && flutterRoot.isNotEmpty) {
+    final flutterSdk = p.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
+    if (Directory(flutterSdk).existsSync()) {
+      return p.normalize(flutterSdk);
+    }
+  }
+
+  final executable = Platform.resolvedExecutable;
+  final executableName = p.basename(executable);
+  if (executableName == 'dart' || executableName == 'dart.exe') {
+    return p.normalize(p.dirname(p.dirname(executable)));
+  }
+
+  final dartOnPath = _dartExecutableOnPath();
+  if (dartOnPath != null) {
+    final binDir = p.dirname(dartOnPath);
+    final flutterCacheSdk = p.join(binDir, 'cache', 'dart-sdk');
+    if (Directory(flutterCacheSdk).existsSync()) {
+      return p.normalize(flutterCacheSdk);
+    }
+
+    if (p.basename(dartOnPath) == 'dart' || p.basename(dartOnPath) == 'dart.exe') {
+      return p.normalize(p.dirname(p.dirname(dartOnPath)));
+    }
+  }
+
+  return null;
+}
+
+String? _dartExecutableOnPath() {
+  try {
+    final result = Process.runSync(Platform.isWindows ? 'where' : 'which', ['dart'], runInShell: true);
+    if (result.exitCode != 0) {
+      return null;
+    }
+
+    final dartPath = result.stdout.toString().trim().split(RegExp(r'\r?\n')).first.trim();
+    if (dartPath.isEmpty || !File(dartPath).existsSync()) {
+      return null;
+    }
+
+    return dartPath;
+  } catch (_) {
+    return null;
+  }
 }

--- a/lib/doc_generator/git_utils.dart
+++ b/lib/doc_generator/git_utils.dart
@@ -68,11 +68,7 @@ class GitUtils {
   /// Checks if the current directory is a Git repository
   static Future<bool> isGitRepository(String? root) async {
     try {
-      final result = await Process.run(
-        'git',
-        ['rev-parse', '--git-dir'],
-        workingDirectory: root,
-      );
+      final result = await Process.run('git', ['rev-parse', '--git-dir'], workingDirectory: root);
       return result.exitCode == 0;
     } catch (e) {
       return false;
@@ -171,8 +167,12 @@ class GitUtils {
     return result.stdout.toString().trim().isNotEmpty;
   }
 
-  static Future<void> commitVersion(String version, String? root,
-      {bool? commitBadge, bool commitChangelog = true}) async {
+  static Future<void> commitVersion(
+    String version,
+    String? root, {
+    bool? commitBadge,
+    bool commitChangelog = true,
+  }) async {
     final filesToCommit = [
       'pubspec.yaml',
       if (commitChangelog) 'CHANGELOG.md',
@@ -180,25 +180,18 @@ class GitUtils {
     ];
 
     // Add files to git to ensure they are tracked
-    final addResult = await Process.run(
-      'git',
-      ['add', ...filesToCommit],
-      workingDirectory: root,
-    );
+    final addResult = await Process.run('git', ['add', ...filesToCommit], workingDirectory: root);
 
     if (addResult.exitCode != 0) {
       throw GitException('Failed to add files to git: ${addResult.stderr.toString()}');
     }
 
-    final result = await Process.run(
-        'git',
-        [
-          'commit',
-          '-m',
-          'chore: bump version to $version [skip ci]',
-          ...filesToCommit,
-        ],
-        workingDirectory: root);
+    final result = await Process.run('git', [
+      'commit',
+      '-m',
+      'chore: bump version to $version [skip ci]',
+      ...filesToCommit,
+    ], workingDirectory: root);
     if (result.exitCode != 0) {
       throw GitException('Failed to commit version $version: ${result.stderr.toString()}');
     }
@@ -213,11 +206,12 @@ class GitUtils {
     // file state from the bump commit but carries no [skip ci]), the tag-triggered
     // publish pipeline fires normally, while the branch push is still suppressed
     // because branch HEAD remains the [skip ci] bump commit.
-    final releaseCommit = await Process.run(
-      'git',
-      ['commit', '--allow-empty', '-m', 'chore(release): $tag'],
-      workingDirectory: root,
-    );
+    final releaseCommit = await Process.run('git', [
+      'commit',
+      '--allow-empty',
+      '-m',
+      'chore(release): $tag',
+    ], workingDirectory: root);
     if (releaseCommit.exitCode != 0) {
       throw GitException('Failed to create release commit: ${releaseCommit.stderr.toString()}');
     }
@@ -281,11 +275,7 @@ class GitUtils {
 
   /// Gets the previous tag ref for a specific package in a workspace
   /// Returns null if no tags exist for the package
-  static Future<String?> getPreviousRefForPackage(
-    String? root,
-    String packageName, {
-    String tagPrefix = 'v',
-  }) async {
+  static Future<String?> getPreviousRefForPackage(String? root, String packageName, {String tagPrefix = 'v'}) async {
     try {
       final tags = await getVersionsForPackage(root, packageName, tagPrefix: tagPrefix);
       if (tags.isEmpty) {
@@ -299,14 +289,7 @@ class GitUtils {
   }
 
   static Future<String> gitShow(String ref, String? root, String path) async {
-    final result = await Process.run(
-      'git',
-      [
-        'show',
-        '$ref:$path',
-      ],
-      workingDirectory: root,
-    );
+    final result = await Process.run('git', ['show', '$ref:$path'], workingDirectory: root);
     if (result.exitCode != 0) {
       throw GitException('Failed to show ref $ref:$path: ${result.stderr.toString()}');
     }
@@ -316,11 +299,7 @@ class GitUtils {
   /// Gets the remote URL of the git repository
   static Future<String?> getRemoteUrl(String? root) async {
     try {
-      final result = await Process.run(
-        'git',
-        ['config', '--get', 'remote.origin.url'],
-        workingDirectory: root,
-      );
+      final result = await Process.run('git', ['config', '--get', 'remote.origin.url'], workingDirectory: root);
       if (result.exitCode == 0) {
         var url = result.stdout.toString().trim();
         if (url.startsWith('git@')) {
@@ -338,12 +317,7 @@ class GitUtils {
   }
 
   /// Builds a comparison URL for a file between two refs
-  static String? buildCompareUrl(
-    String? remoteUrl,
-    String? baseRef,
-    String? newRef,
-    String filePath,
-  ) {
+  static String? buildCompareUrl(String? remoteUrl, String? baseRef, String? newRef, String filePath) {
     if (remoteUrl == null || baseRef == null || newRef == null) {
       return null;
     }
@@ -353,11 +327,7 @@ class GitUtils {
 
   /// Gets the commits between two refs
   /// If [fromRef] is null, it gets all commits up to [toRef] (or HEAD if [toRef] is null)
-  static Future<List<Commit>> getCommits({
-    required String root,
-    String? fromRef,
-    String? toRef,
-  }) async {
+  static Future<List<Commit>> getCommits({required String root, String? fromRef, String? toRef}) async {
     try {
       final gitArgs = ['--no-pager', 'log', '--no-decorate'];
       if (fromRef != null) {
@@ -366,11 +336,7 @@ class GitUtils {
         gitArgs.add(toRef);
       }
 
-      final commitResult = await Process.run(
-        'git',
-        gitArgs,
-        workingDirectory: root,
-      );
+      final commitResult = await Process.run('git', gitArgs, workingDirectory: root);
 
       if (commitResult.exitCode == 0) {
         return Commit.parseCommits(commitResult.stdout.toString().trim());
@@ -386,17 +352,10 @@ class GitUtils {
   /// If the latest tag matches the current version (e.g. CI running on tagged commit),
   /// it gets the commits since the previous tag.
   /// If they do not match (e.g. preparing for a new release), it gets commits since the latest tag.
-  static Future<List<Commit>> getCommitsSinceLastTag(
-    String root,
-    String currentVersion,
-  ) async {
+  static Future<List<Commit>> getCommitsSinceLastTag(String root, String currentVersion) async {
     try {
       // Get all tags sorted by creation date (newest first)
-      final tagsResult = await Process.run(
-        'git',
-        ['tag', '--sort=-creatordate'],
-        workingDirectory: root,
-      );
+      final tagsResult = await Process.run('git', ['tag', '--sort=-creatordate'], workingDirectory: root);
 
       if (tagsResult.exitCode == 0) {
         final tags = tagsResult.stdout.toString().trim().split('\n').where((tag) => tag.isNotEmpty).toList();
@@ -457,11 +416,7 @@ class GitUtils {
       }
 
       // Create the worktree
-      final result = await Process.run(
-        'git',
-        ['worktree', 'add', worktreePath, ref],
-        workingDirectory: gitRoot,
-      );
+      final result = await Process.run('git', ['worktree', 'add', worktreePath, ref], workingDirectory: gitRoot);
       if (result.exitCode != 0) {
         throw GitException('Failed to create worktree for ref $ref at $worktreePath: ${result.stderr}');
       }
@@ -478,11 +433,12 @@ class GitUtils {
   static Future<void> removeWorktree(String gitRoot, String worktreePath) async {
     try {
       // Use --force to handle cases where worktree has uncommitted changes or is locked
-      final result = await Process.run(
-        'git',
-        ['worktree', 'remove', '--force', worktreePath],
-        workingDirectory: gitRoot,
-      );
+      final result = await Process.run('git', [
+        'worktree',
+        'remove',
+        '--force',
+        worktreePath,
+      ], workingDirectory: gitRoot);
       if (result.exitCode != 0) {
         // If worktree remove fails, try to remove the directory manually
         final dir = Directory(worktreePath);
@@ -492,7 +448,8 @@ class GitUtils {
             dir.deleteSync(recursive: true);
           } catch (e) {
             throw GitException(
-                'Failed to remove worktree at $worktreePath: ${result.stderr}. Manual cleanup also failed: $e');
+              'Failed to remove worktree at $worktreePath: ${result.stderr}. Manual cleanup also failed: $e',
+            );
           }
         } else {
           // Directory doesn't exist, consider it cleaned up
@@ -510,11 +467,7 @@ class GitUtils {
   /// Checks if a worktree exists at the specified path
   static Future<bool> worktreeExists(String gitRoot, String worktreePath) async {
     try {
-      final result = await Process.run(
-        'git',
-        ['worktree', 'list'],
-        workingDirectory: gitRoot,
-      );
+      final result = await Process.run('git', ['worktree', 'list'], workingDirectory: gitRoot);
       if (result.exitCode != 0) {
         return false;
       }
@@ -537,11 +490,7 @@ class GitUtils {
   /// Returns a list of worktree paths
   static Future<List<String>> listWorktrees(String gitRoot) async {
     try {
-      final result = await Process.run(
-        'git',
-        ['worktree', 'list'],
-        workingDirectory: gitRoot,
-      );
+      final result = await Process.run('git', ['worktree', 'list'], workingDirectory: gitRoot);
       if (result.exitCode != 0) {
         return [];
       }

--- a/lib/doc_generator/pubspec_analyzer.dart
+++ b/lib/doc_generator/pubspec_analyzer.dart
@@ -67,10 +67,7 @@ class PubspecAnalyzer {
         // Ignore path/git dependencies for version tracking if needed,
         // or include them with null version.
         // dart_apitool includes hosted, path, and git.
-        dependencies.add(PackageDependency(
-          packageName: key.toString(),
-          packageVersion: version,
-        ));
+        dependencies.add(PackageDependency(packageName: key.toString(), packageVersion: version));
       });
     }
     return dependencies;
@@ -80,8 +77,10 @@ class PubspecAnalyzer {
     final androidDir = Directory(path.join(packagePath, 'android'));
     if (!await androidDir.exists()) return null;
 
-    final gradleFiles =
-        await androidDir.list(recursive: true).where((file) => path.extension(file.path) == '.gradle').toList();
+    final gradleFiles = await androidDir
+        .list(recursive: true)
+        .where((file) => path.extension(file.path) == '.gradle')
+        .toList();
 
     AndroidPlatformConstraints? constraints;
 
@@ -131,8 +130,9 @@ class PubspecAnalyzer {
     if (a == null) return b;
     return AndroidPlatformConstraints(
       minSdkVersion: (a.minSdkVersion ?? 0) > (b.minSdkVersion ?? 0) ? a.minSdkVersion : b.minSdkVersion,
-      compileSdkVersion:
-          (a.compileSdkVersion ?? 0) > (b.compileSdkVersion ?? 0) ? a.compileSdkVersion : b.compileSdkVersion,
+      compileSdkVersion: (a.compileSdkVersion ?? 0) > (b.compileSdkVersion ?? 0)
+          ? a.compileSdkVersion
+          : b.compileSdkVersion,
       targetSdkVersion: (a.targetSdkVersion ?? 0) > (b.targetSdkVersion ?? 0) ? a.targetSdkVersion : b.targetSdkVersion,
     );
   }
@@ -144,8 +144,10 @@ class PubspecAnalyzer {
     IOSPlatformConstraints? constraints;
 
     // Check Info.plist files
-    final plistFiles =
-        await iosDir.list(recursive: true).where((file) => path.extension(file.path) == '.plist').toList();
+    final plistFiles = await iosDir
+        .list(recursive: true)
+        .where((file) => path.extension(file.path) == '.plist')
+        .toList();
 
     for (final file in plistFiles) {
       if (file is File) {
@@ -160,8 +162,10 @@ class PubspecAnalyzer {
     }
 
     // Check Podspec files
-    final podspecFiles =
-        await iosDir.list(recursive: true).where((file) => path.extension(file.path) == '.podspec').toList();
+    final podspecFiles = await iosDir
+        .list(recursive: true)
+        .where((file) => path.extension(file.path) == '.podspec')
+        .toList();
 
     for (final file in podspecFiles) {
       if (file is File) {

--- a/lib/models/doc_items.dart
+++ b/lib/models/doc_items.dart
@@ -61,11 +61,7 @@ class DocComponent {
 
   factory DocComponent.fromJson(Map<String, dynamic> json) => _$DocComponentFromJson(json);
 
-  factory DocComponent.meta({
-    required String name,
-    required String description,
-    String? filePath,
-  }) {
+  factory DocComponent.meta({required String name, required String description, String? filePath}) {
     return DocComponent(
       name: name,
       type: DocComponentType.metaType,

--- a/lib/models/doc_items.g.dart
+++ b/lib/models/doc_items.g.dart
@@ -7,47 +7,52 @@ part of 'doc_items.dart';
 // **************************************************************************
 
 DocComponent _$DocComponentFromJson(Map<String, dynamic> json) => DocComponent(
-      name: json['name'] as String,
-      description: json['description'] as String,
-      constructors: (json['constructors'] as List<dynamic>)
-          .map((e) => DocConstructor.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      properties: (json['properties'] as List<dynamic>)
-          .map((e) => DocProperty.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      methods: (json['methods'] as List<dynamic>)
-          .map((e) => DocMethod.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      filePath: json['filePath'] as String?,
-      entryPoint: json['entryPoint'] as String?,
-      type: $enumDecodeNullable(_$DocComponentTypeEnumMap, json['type']) ??
-          DocComponentType.classType,
-      aliasedType: json['aliasedType'] as String?,
-      annotations: (json['annotations'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      superClasses: (json['superClasses'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      superClassPackages: (json['superClassPackages'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      interfaces: (json['interfaces'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      mixins: (json['mixins'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      typeParameters: (json['typeParameters'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-    );
+  name: json['name'] as String,
+  description: json['description'] as String,
+  constructors: (json['constructors'] as List<dynamic>)
+      .map((e) => DocConstructor.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  properties: (json['properties'] as List<dynamic>)
+      .map((e) => DocProperty.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  methods: (json['methods'] as List<dynamic>)
+      .map((e) => DocMethod.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  filePath: json['filePath'] as String?,
+  entryPoint: json['entryPoint'] as String?,
+  type:
+      $enumDecodeNullable(_$DocComponentTypeEnumMap, json['type']) ??
+      DocComponentType.classType,
+  aliasedType: json['aliasedType'] as String?,
+  annotations:
+      (json['annotations'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  superClasses:
+      (json['superClasses'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  superClassPackages:
+      (json['superClassPackages'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  interfaces:
+      (json['interfaces'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  mixins:
+      (json['mixins'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      const [],
+  typeParameters:
+      (json['typeParameters'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+);
 
 Map<String, dynamic> _$DocComponentToJson(DocComponent instance) =>
     <String, dynamic>{
@@ -79,16 +84,18 @@ const _$DocComponentTypeEnumMap = {
 };
 
 DocProperty _$DocPropertyFromJson(Map<String, dynamic> json) => DocProperty(
-      name: json['name'] as String,
-      type: DocType.fromJson(json['type'] as Map<String, dynamic>),
-      description: json['description'] as String,
-      features:
-          (json['features'] as List<dynamic>).map((e) => e as String).toList(),
-      annotations: (json['annotations'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-    );
+  name: json['name'] as String,
+  type: DocType.fromJson(json['type'] as Map<String, dynamic>),
+  description: json['description'] as String,
+  features: (json['features'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  annotations:
+      (json['annotations'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+);
 
 Map<String, dynamic> _$DocPropertyToJson(DocProperty instance) =>
     <String, dynamic>{
@@ -105,9 +112,11 @@ DocConstructor _$DocConstructorFromJson(Map<String, dynamic> json) =>
       signature: (json['signature'] as List<dynamic>)
           .map((e) => DocParameter.fromJson(e as Map<String, dynamic>))
           .toList(),
-      features:
-          (json['features'] as List<dynamic>).map((e) => e as String).toList(),
-      annotations: (json['annotations'] as List<dynamic>?)
+      features: (json['features'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      annotations:
+          (json['annotations'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
           const [],
@@ -122,17 +131,18 @@ Map<String, dynamic> _$DocConstructorToJson(DocConstructor instance) =>
     };
 
 DocParameter _$DocParameterFromJson(Map<String, dynamic> json) => DocParameter(
-      name: json['name'] as String,
-      type: DocType.fromJson(json['type'] as Map<String, dynamic>),
-      description: json['description'] as String,
-      named: json['named'] as bool,
-      required: json['required'] as bool,
-      defaultValue: json['defaultValue'] as String?,
-      annotations: (json['annotations'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-    );
+  name: json['name'] as String,
+  type: DocType.fromJson(json['type'] as Map<String, dynamic>),
+  description: json['description'] as String,
+  named: json['named'] as bool,
+  required: json['required'] as bool,
+  defaultValue: json['defaultValue'] as String?,
+  annotations:
+      (json['annotations'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+);
 
 Map<String, dynamic> _$DocParameterToJson(DocParameter instance) =>
     <String, dynamic>{
@@ -146,30 +156,33 @@ Map<String, dynamic> _$DocParameterToJson(DocParameter instance) =>
     };
 
 DocMethod _$DocMethodFromJson(Map<String, dynamic> json) => DocMethod(
-      name: json['name'] as String,
-      returnType: DocType.fromJson(json['returnType'] as Map<String, dynamic>),
-      signature: (json['signature'] as List<dynamic>)
-          .map((e) => DocParameter.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      features:
-          (json['features'] as List<dynamic>).map((e) => e as String).toList(),
-      description: json['description'] as String,
-      annotations: (json['annotations'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      typeParameters: (json['typeParameters'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-    );
+  name: json['name'] as String,
+  returnType: DocType.fromJson(json['returnType'] as Map<String, dynamic>),
+  signature: (json['signature'] as List<dynamic>)
+      .map((e) => DocParameter.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  features: (json['features'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  description: json['description'] as String,
+  annotations:
+      (json['annotations'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  typeParameters:
+      (json['typeParameters'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+);
 
 Map<String, dynamic> _$DocMethodToJson(DocMethod instance) => <String, dynamic>{
-      'name': instance.name,
-      'returnType': instance.returnType,
-      'signature': instance.signature,
-      'features': instance.features,
-      'description': instance.description,
-      'annotations': instance.annotations,
-      'typeParameters': instance.typeParameters,
-    };
+  'name': instance.name,
+  'returnType': instance.returnType,
+  'signature': instance.signature,
+  'features': instance.features,
+  'description': instance.description,
+  'annotations': instance.annotations,
+  'typeParameters': instance.typeParameters,
+};

--- a/lib/models/doc_items.g.dart
+++ b/lib/models/doc_items.g.dart
@@ -15,63 +15,36 @@ DocComponent _$DocComponentFromJson(Map<String, dynamic> json) => DocComponent(
   properties: (json['properties'] as List<dynamic>)
       .map((e) => DocProperty.fromJson(e as Map<String, dynamic>))
       .toList(),
-  methods: (json['methods'] as List<dynamic>)
-      .map((e) => DocMethod.fromJson(e as Map<String, dynamic>))
-      .toList(),
+  methods: (json['methods'] as List<dynamic>).map((e) => DocMethod.fromJson(e as Map<String, dynamic>)).toList(),
   filePath: json['filePath'] as String?,
   entryPoint: json['entryPoint'] as String?,
-  type:
-      $enumDecodeNullable(_$DocComponentTypeEnumMap, json['type']) ??
-      DocComponentType.classType,
+  type: $enumDecodeNullable(_$DocComponentTypeEnumMap, json['type']) ?? DocComponentType.classType,
   aliasedType: json['aliasedType'] as String?,
-  annotations:
-      (json['annotations'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
-  superClasses:
-      (json['superClasses'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
-  superClassPackages:
-      (json['superClassPackages'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
-  interfaces:
-      (json['interfaces'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
-  mixins:
-      (json['mixins'] as List<dynamic>?)?.map((e) => e as String).toList() ??
-      const [],
-  typeParameters:
-      (json['typeParameters'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
+  annotations: (json['annotations'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+  superClasses: (json['superClasses'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+  superClassPackages: (json['superClassPackages'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+  interfaces: (json['interfaces'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+  mixins: (json['mixins'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+  typeParameters: (json['typeParameters'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
 );
 
-Map<String, dynamic> _$DocComponentToJson(DocComponent instance) =>
-    <String, dynamic>{
-      'filePath': instance.filePath,
-      'entryPoint': instance.entryPoint,
-      'name': instance.name,
-      'description': instance.description,
-      'constructors': instance.constructors,
-      'properties': instance.properties,
-      'methods': instance.methods,
-      'type': _$DocComponentTypeEnumMap[instance.type]!,
-      'aliasedType': instance.aliasedType,
-      'annotations': instance.annotations,
-      'superClasses': instance.superClasses,
-      'superClassPackages': instance.superClassPackages,
-      'interfaces': instance.interfaces,
-      'mixins': instance.mixins,
-      'typeParameters': instance.typeParameters,
-    };
+Map<String, dynamic> _$DocComponentToJson(DocComponent instance) => <String, dynamic>{
+  'filePath': instance.filePath,
+  'entryPoint': instance.entryPoint,
+  'name': instance.name,
+  'description': instance.description,
+  'constructors': instance.constructors,
+  'properties': instance.properties,
+  'methods': instance.methods,
+  'type': _$DocComponentTypeEnumMap[instance.type]!,
+  'aliasedType': instance.aliasedType,
+  'annotations': instance.annotations,
+  'superClasses': instance.superClasses,
+  'superClassPackages': instance.superClassPackages,
+  'interfaces': instance.interfaces,
+  'mixins': instance.mixins,
+  'typeParameters': instance.typeParameters,
+};
 
 const _$DocComponentTypeEnumMap = {
   DocComponentType.classType: 'class',
@@ -87,48 +60,31 @@ DocProperty _$DocPropertyFromJson(Map<String, dynamic> json) => DocProperty(
   name: json['name'] as String,
   type: DocType.fromJson(json['type'] as Map<String, dynamic>),
   description: json['description'] as String,
-  features: (json['features'] as List<dynamic>)
-      .map((e) => e as String)
-      .toList(),
-  annotations:
-      (json['annotations'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
+  features: (json['features'] as List<dynamic>).map((e) => e as String).toList(),
+  annotations: (json['annotations'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
 );
 
-Map<String, dynamic> _$DocPropertyToJson(DocProperty instance) =>
-    <String, dynamic>{
-      'name': instance.name,
-      'type': instance.type,
-      'description': instance.description,
-      'features': instance.features,
-      'annotations': instance.annotations,
-    };
+Map<String, dynamic> _$DocPropertyToJson(DocProperty instance) => <String, dynamic>{
+  'name': instance.name,
+  'type': instance.type,
+  'description': instance.description,
+  'features': instance.features,
+  'annotations': instance.annotations,
+};
 
-DocConstructor _$DocConstructorFromJson(Map<String, dynamic> json) =>
-    DocConstructor(
-      name: json['name'] as String,
-      signature: (json['signature'] as List<dynamic>)
-          .map((e) => DocParameter.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      features: (json['features'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
-      annotations:
-          (json['annotations'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-    );
+DocConstructor _$DocConstructorFromJson(Map<String, dynamic> json) => DocConstructor(
+  name: json['name'] as String,
+  signature: (json['signature'] as List<dynamic>).map((e) => DocParameter.fromJson(e as Map<String, dynamic>)).toList(),
+  features: (json['features'] as List<dynamic>).map((e) => e as String).toList(),
+  annotations: (json['annotations'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+);
 
-Map<String, dynamic> _$DocConstructorToJson(DocConstructor instance) =>
-    <String, dynamic>{
-      'name': instance.name,
-      'signature': instance.signature,
-      'features': instance.features,
-      'annotations': instance.annotations,
-    };
+Map<String, dynamic> _$DocConstructorToJson(DocConstructor instance) => <String, dynamic>{
+  'name': instance.name,
+  'signature': instance.signature,
+  'features': instance.features,
+  'annotations': instance.annotations,
+};
 
 DocParameter _$DocParameterFromJson(Map<String, dynamic> json) => DocParameter(
   name: json['name'] as String,
@@ -137,44 +93,27 @@ DocParameter _$DocParameterFromJson(Map<String, dynamic> json) => DocParameter(
   named: json['named'] as bool,
   required: json['required'] as bool,
   defaultValue: json['defaultValue'] as String?,
-  annotations:
-      (json['annotations'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
+  annotations: (json['annotations'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
 );
 
-Map<String, dynamic> _$DocParameterToJson(DocParameter instance) =>
-    <String, dynamic>{
-      'name': instance.name,
-      'description': instance.description,
-      'type': instance.type,
-      'named': instance.named,
-      'required': instance.required,
-      'defaultValue': instance.defaultValue,
-      'annotations': instance.annotations,
-    };
+Map<String, dynamic> _$DocParameterToJson(DocParameter instance) => <String, dynamic>{
+  'name': instance.name,
+  'description': instance.description,
+  'type': instance.type,
+  'named': instance.named,
+  'required': instance.required,
+  'defaultValue': instance.defaultValue,
+  'annotations': instance.annotations,
+};
 
 DocMethod _$DocMethodFromJson(Map<String, dynamic> json) => DocMethod(
   name: json['name'] as String,
   returnType: DocType.fromJson(json['returnType'] as Map<String, dynamic>),
-  signature: (json['signature'] as List<dynamic>)
-      .map((e) => DocParameter.fromJson(e as Map<String, dynamic>))
-      .toList(),
-  features: (json['features'] as List<dynamic>)
-      .map((e) => e as String)
-      .toList(),
+  signature: (json['signature'] as List<dynamic>).map((e) => DocParameter.fromJson(e as Map<String, dynamic>)).toList(),
+  features: (json['features'] as List<dynamic>).map((e) => e as String).toList(),
   description: json['description'] as String,
-  annotations:
-      (json['annotations'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
-  typeParameters:
-      (json['typeParameters'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
+  annotations: (json['annotations'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+  typeParameters: (json['typeParameters'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
 );
 
 Map<String, dynamic> _$DocMethodToJson(DocMethod instance) => <String, dynamic>{

--- a/lib/models/doc_type.dart
+++ b/lib/models/doc_type.dart
@@ -8,11 +8,7 @@ class DocType {
   final List<String> superTypes;
   final bool isNullable;
 
-  const DocType({
-    required this.name,
-    this.superTypes = const [],
-    this.isNullable = false,
-  });
+  const DocType({required this.name, this.superTypes = const [], this.isNullable = false});
 
   factory DocType.fromJson(Map<String, dynamic> json) => _$DocTypeFromJson(json);
 

--- a/lib/models/doc_type.g.dart
+++ b/lib/models/doc_type.g.dart
@@ -7,16 +7,17 @@ part of 'doc_type.dart';
 // **************************************************************************
 
 DocType _$DocTypeFromJson(Map<String, dynamic> json) => DocType(
-      name: json['name'] as String,
-      superTypes: (json['superTypes'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
-      isNullable: json['isNullable'] as bool? ?? false,
-    );
+  name: json['name'] as String,
+  superTypes:
+      (json['superTypes'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  isNullable: json['isNullable'] as bool? ?? false,
+);
 
 Map<String, dynamic> _$DocTypeToJson(DocType instance) => <String, dynamic>{
-      'name': instance.name,
-      'superTypes': instance.superTypes,
-      'isNullable': instance.isNullable,
-    };
+  'name': instance.name,
+  'superTypes': instance.superTypes,
+  'isNullable': instance.isNullable,
+};

--- a/lib/models/doc_type.g.dart
+++ b/lib/models/doc_type.g.dart
@@ -8,11 +8,7 @@ part of 'doc_type.dart';
 
 DocType _$DocTypeFromJson(Map<String, dynamic> json) => DocType(
   name: json['name'] as String,
-  superTypes:
-      (json['superTypes'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      const [],
+  superTypes: (json['superTypes'] as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
   isNullable: json['isNullable'] as bool? ?? false,
 );
 

--- a/lib/models/package_info.dart
+++ b/lib/models/package_info.dart
@@ -8,10 +8,7 @@ class PackageApi {
   final PackageMetadata metadata;
   final List<DocComponent> components;
 
-  PackageApi({
-    required this.metadata,
-    required this.components,
-  });
+  PackageApi({required this.metadata, required this.components});
 
   factory PackageApi.fromJson(Map<String, dynamic> json) => _$PackageApiFromJson(json);
   Map<String, dynamic> toJson() => _$PackageApiToJson(this);
@@ -46,10 +43,7 @@ class PackageDependency {
   final String packageName;
   final String? packageVersion;
 
-  PackageDependency({
-    required this.packageName,
-    this.packageVersion,
-  });
+  PackageDependency({required this.packageName, this.packageVersion});
 
   factory PackageDependency.fromJson(Map<String, dynamic> json) => _$PackageDependencyFromJson(json);
   Map<String, dynamic> toJson() => _$PackageDependencyToJson(this);
@@ -61,11 +55,7 @@ class AndroidPlatformConstraints {
   final int? compileSdkVersion;
   final int? targetSdkVersion;
 
-  AndroidPlatformConstraints({
-    this.minSdkVersion,
-    this.compileSdkVersion,
-    this.targetSdkVersion,
-  });
+  AndroidPlatformConstraints({this.minSdkVersion, this.compileSdkVersion, this.targetSdkVersion});
 
   factory AndroidPlatformConstraints.fromJson(Map<String, dynamic> json) => _$AndroidPlatformConstraintsFromJson(json);
   Map<String, dynamic> toJson() => _$AndroidPlatformConstraintsToJson(this);
@@ -75,9 +65,7 @@ class AndroidPlatformConstraints {
 class IOSPlatformConstraints {
   final num? minimumOsVersion;
 
-  IOSPlatformConstraints({
-    this.minimumOsVersion,
-  });
+  IOSPlatformConstraints({this.minimumOsVersion});
 
   factory IOSPlatformConstraints.fromJson(Map<String, dynamic> json) => _$IOSPlatformConstraintsFromJson(json);
   Map<String, dynamic> toJson() => _$IOSPlatformConstraintsToJson(this);

--- a/lib/models/package_info.g.dart
+++ b/lib/models/package_info.g.dart
@@ -13,80 +13,63 @@ PackageApi _$PackageApiFromJson(Map<String, dynamic> json) => PackageApi(
       .toList(),
 );
 
-Map<String, dynamic> _$PackageApiToJson(PackageApi instance) =>
-    <String, dynamic>{
-      'metadata': instance.metadata,
-      'components': instance.components,
-    };
+Map<String, dynamic> _$PackageApiToJson(PackageApi instance) => <String, dynamic>{
+  'metadata': instance.metadata,
+  'components': instance.components,
+};
 
-PackageMetadata _$PackageMetadataFromJson(Map<String, dynamic> json) =>
-    PackageMetadata(
-      packageName: json['packageName'] as String?,
-      packageVersion: json['packageVersion'] as String?,
-      sdkVersion: json['sdkVersion'] as String?,
-      flutterVersion: json['flutterVersion'] as String?,
-      dependencies:
-          (json['dependencies'] as List<dynamic>?)
-              ?.map(
-                (e) => PackageDependency.fromJson(e as Map<String, dynamic>),
-              )
-              .toList() ??
-          const [],
-      androidConstraints: json['androidConstraints'] == null
-          ? null
-          : AndroidPlatformConstraints.fromJson(
-              json['androidConstraints'] as Map<String, dynamic>,
-            ),
-      iosConstraints: json['iosConstraints'] == null
-          ? null
-          : IOSPlatformConstraints.fromJson(
-              json['iosConstraints'] as Map<String, dynamic>,
-            ),
-    );
-
-Map<String, dynamic> _$PackageMetadataToJson(PackageMetadata instance) =>
-    <String, dynamic>{
-      'packageName': instance.packageName,
-      'packageVersion': instance.packageVersion,
-      'sdkVersion': instance.sdkVersion,
-      'flutterVersion': instance.flutterVersion,
-      'dependencies': instance.dependencies,
-      'androidConstraints': instance.androidConstraints,
-      'iosConstraints': instance.iosConstraints,
-    };
-
-PackageDependency _$PackageDependencyFromJson(Map<String, dynamic> json) =>
-    PackageDependency(
-      packageName: json['packageName'] as String,
-      packageVersion: json['packageVersion'] as String?,
-    );
-
-Map<String, dynamic> _$PackageDependencyToJson(PackageDependency instance) =>
-    <String, dynamic>{
-      'packageName': instance.packageName,
-      'packageVersion': instance.packageVersion,
-    };
-
-AndroidPlatformConstraints _$AndroidPlatformConstraintsFromJson(
-  Map<String, dynamic> json,
-) => AndroidPlatformConstraints(
-  minSdkVersion: (json['minSdkVersion'] as num?)?.toInt(),
-  compileSdkVersion: (json['compileSdkVersion'] as num?)?.toInt(),
-  targetSdkVersion: (json['targetSdkVersion'] as num?)?.toInt(),
+PackageMetadata _$PackageMetadataFromJson(Map<String, dynamic> json) => PackageMetadata(
+  packageName: json['packageName'] as String?,
+  packageVersion: json['packageVersion'] as String?,
+  sdkVersion: json['sdkVersion'] as String?,
+  flutterVersion: json['flutterVersion'] as String?,
+  dependencies:
+      (json['dependencies'] as List<dynamic>?)
+          ?.map((e) => PackageDependency.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
+  androidConstraints: json['androidConstraints'] == null
+      ? null
+      : AndroidPlatformConstraints.fromJson(json['androidConstraints'] as Map<String, dynamic>),
+  iosConstraints: json['iosConstraints'] == null
+      ? null
+      : IOSPlatformConstraints.fromJson(json['iosConstraints'] as Map<String, dynamic>),
 );
 
-Map<String, dynamic> _$AndroidPlatformConstraintsToJson(
-  AndroidPlatformConstraints instance,
-) => <String, dynamic>{
+Map<String, dynamic> _$PackageMetadataToJson(PackageMetadata instance) => <String, dynamic>{
+  'packageName': instance.packageName,
+  'packageVersion': instance.packageVersion,
+  'sdkVersion': instance.sdkVersion,
+  'flutterVersion': instance.flutterVersion,
+  'dependencies': instance.dependencies,
+  'androidConstraints': instance.androidConstraints,
+  'iosConstraints': instance.iosConstraints,
+};
+
+PackageDependency _$PackageDependencyFromJson(Map<String, dynamic> json) =>
+    PackageDependency(packageName: json['packageName'] as String, packageVersion: json['packageVersion'] as String?);
+
+Map<String, dynamic> _$PackageDependencyToJson(PackageDependency instance) => <String, dynamic>{
+  'packageName': instance.packageName,
+  'packageVersion': instance.packageVersion,
+};
+
+AndroidPlatformConstraints _$AndroidPlatformConstraintsFromJson(Map<String, dynamic> json) =>
+    AndroidPlatformConstraints(
+      minSdkVersion: (json['minSdkVersion'] as num?)?.toInt(),
+      compileSdkVersion: (json['compileSdkVersion'] as num?)?.toInt(),
+      targetSdkVersion: (json['targetSdkVersion'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$AndroidPlatformConstraintsToJson(AndroidPlatformConstraints instance) => <String, dynamic>{
   'minSdkVersion': instance.minSdkVersion,
   'compileSdkVersion': instance.compileSdkVersion,
   'targetSdkVersion': instance.targetSdkVersion,
 };
 
-IOSPlatformConstraints _$IOSPlatformConstraintsFromJson(
-  Map<String, dynamic> json,
-) => IOSPlatformConstraints(minimumOsVersion: json['minimumOsVersion'] as num?);
+IOSPlatformConstraints _$IOSPlatformConstraintsFromJson(Map<String, dynamic> json) =>
+    IOSPlatformConstraints(minimumOsVersion: json['minimumOsVersion'] as num?);
 
-Map<String, dynamic> _$IOSPlatformConstraintsToJson(
-  IOSPlatformConstraints instance,
-) => <String, dynamic>{'minimumOsVersion': instance.minimumOsVersion};
+Map<String, dynamic> _$IOSPlatformConstraintsToJson(IOSPlatformConstraints instance) => <String, dynamic>{
+  'minimumOsVersion': instance.minimumOsVersion,
+};

--- a/lib/models/package_info.g.dart
+++ b/lib/models/package_info.g.dart
@@ -7,12 +7,11 @@ part of 'package_info.dart';
 // **************************************************************************
 
 PackageApi _$PackageApiFromJson(Map<String, dynamic> json) => PackageApi(
-      metadata:
-          PackageMetadata.fromJson(json['metadata'] as Map<String, dynamic>),
-      components: (json['components'] as List<dynamic>)
-          .map((e) => DocComponent.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
+  metadata: PackageMetadata.fromJson(json['metadata'] as Map<String, dynamic>),
+  components: (json['components'] as List<dynamic>)
+      .map((e) => DocComponent.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
 
 Map<String, dynamic> _$PackageApiToJson(PackageApi instance) =>
     <String, dynamic>{
@@ -26,19 +25,23 @@ PackageMetadata _$PackageMetadataFromJson(Map<String, dynamic> json) =>
       packageVersion: json['packageVersion'] as String?,
       sdkVersion: json['sdkVersion'] as String?,
       flutterVersion: json['flutterVersion'] as String?,
-      dependencies: (json['dependencies'] as List<dynamic>?)
+      dependencies:
+          (json['dependencies'] as List<dynamic>?)
               ?.map(
-                  (e) => PackageDependency.fromJson(e as Map<String, dynamic>))
+                (e) => PackageDependency.fromJson(e as Map<String, dynamic>),
+              )
               .toList() ??
           const [],
       androidConstraints: json['androidConstraints'] == null
           ? null
           : AndroidPlatformConstraints.fromJson(
-              json['androidConstraints'] as Map<String, dynamic>),
+              json['androidConstraints'] as Map<String, dynamic>,
+            ),
       iosConstraints: json['iosConstraints'] == null
           ? null
           : IOSPlatformConstraints.fromJson(
-              json['iosConstraints'] as Map<String, dynamic>),
+              json['iosConstraints'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$PackageMetadataToJson(PackageMetadata instance) =>
@@ -65,29 +68,25 @@ Map<String, dynamic> _$PackageDependencyToJson(PackageDependency instance) =>
     };
 
 AndroidPlatformConstraints _$AndroidPlatformConstraintsFromJson(
-        Map<String, dynamic> json) =>
-    AndroidPlatformConstraints(
-      minSdkVersion: (json['minSdkVersion'] as num?)?.toInt(),
-      compileSdkVersion: (json['compileSdkVersion'] as num?)?.toInt(),
-      targetSdkVersion: (json['targetSdkVersion'] as num?)?.toInt(),
-    );
+  Map<String, dynamic> json,
+) => AndroidPlatformConstraints(
+  minSdkVersion: (json['minSdkVersion'] as num?)?.toInt(),
+  compileSdkVersion: (json['compileSdkVersion'] as num?)?.toInt(),
+  targetSdkVersion: (json['targetSdkVersion'] as num?)?.toInt(),
+);
 
 Map<String, dynamic> _$AndroidPlatformConstraintsToJson(
-        AndroidPlatformConstraints instance) =>
-    <String, dynamic>{
-      'minSdkVersion': instance.minSdkVersion,
-      'compileSdkVersion': instance.compileSdkVersion,
-      'targetSdkVersion': instance.targetSdkVersion,
-    };
+  AndroidPlatformConstraints instance,
+) => <String, dynamic>{
+  'minSdkVersion': instance.minSdkVersion,
+  'compileSdkVersion': instance.compileSdkVersion,
+  'targetSdkVersion': instance.targetSdkVersion,
+};
 
 IOSPlatformConstraints _$IOSPlatformConstraintsFromJson(
-        Map<String, dynamic> json) =>
-    IOSPlatformConstraints(
-      minimumOsVersion: json['minimumOsVersion'] as num?,
-    );
+  Map<String, dynamic> json,
+) => IOSPlatformConstraints(minimumOsVersion: json['minimumOsVersion'] as num?);
 
 Map<String, dynamic> _$IOSPlatformConstraintsToJson(
-        IOSPlatformConstraints instance) =>
-    <String, dynamic>{
-      'minimumOsVersion': instance.minimumOsVersion,
-    };
+  IOSPlatformConstraints instance,
+) => <String, dynamic>{'minimumOsVersion': instance.minimumOsVersion};

--- a/lib/pubspec_utils.dart
+++ b/lib/pubspec_utils.dart
@@ -58,11 +58,7 @@ class PubspecUtils {
 
   /// Updates a workspace dependency version while maintaining constraint format
   /// Updates both dependencies and dev_dependencies sections
-  static Future<void> updateWorkspaceDependency(
-    File pubspec,
-    String packageName,
-    Version newVersion,
-  ) async {
+  static Future<void> updateWorkspaceDependency(File pubspec, String packageName, Version newVersion) async {
     final pubspecEditor = await _getPubspec(pubspec.path);
     final pubspecContent = await pubspec.readAsString();
     final pubspecYaml = loadYaml(pubspecContent) as Map;

--- a/lib/version/version.dart
+++ b/lib/version/version.dart
@@ -20,19 +20,10 @@ class VersionResult {
   final String? changelog;
   final String? badge;
 
-  VersionResult({
-    required this.version,
-    required this.apiChanges,
-    required this.changelog,
-    required this.badge,
-  });
+  VersionResult({required this.version, required this.apiChanges, required this.changelog, required this.badge});
 
   Map<String, dynamic> toJson() {
-    return {
-      'version': version.toString(),
-      'changelog': changelog,
-      'badge': badge,
-    };
+    return {'version': version.toString(), 'changelog': changelog, 'badge': badge};
   }
 }
 
@@ -63,10 +54,11 @@ Future<VersionResult> version({
     exit(1);
   }
 
-  final effectiveBaseRef = baseRef ??
+  final effectiveBaseRef =
+      baseRef ??
       (packageName != null
           ? await GitUtils.getPreviousRefForPackage(gitRoot.path, packageName, tagPrefix: 'v') ??
-              (throw Exception('No previous version found for package $packageName'))
+                (throw Exception('No previous version found for package $packageName'))
           : await GitUtils.getPreviousRef(gitRoot.path, tagPrefix: tagPrefix));
 
   final changes = await compare(
@@ -77,18 +69,15 @@ Future<VersionResult> version({
     cache: cache,
   );
 
-  final pubspecPath =
-      packageName != null ? join(relative(dartRoot.path, from: gitRoot.path), 'pubspec.yaml') : 'pubspec.yaml';
+  final pubspecPath = packageName != null
+      ? join(relative(dartRoot.path, from: gitRoot.path), 'pubspec.yaml')
+      : 'pubspec.yaml';
 
   // Load config and apply magnitude overrides
   final config = ApiGuardConfig.load(dartRoot);
   applyMagnitudeOverrides(changes, config);
 
-  final basePubSpec = await GitUtils.gitShow(
-    effectiveBaseRef,
-    gitRoot.path,
-    pubspecPath,
-  );
+  final basePubSpec = await GitUtils.gitShow(effectiveBaseRef, gitRoot.path, pubspecPath);
 
   final baseVersion = PubspecUtils.getVersion(basePubSpec);
 
@@ -146,12 +135,7 @@ Future<VersionResult> version({
     // For workspace packages, commit from the package directory
     // For single packages, commit from git root
     final commitRoot = packageName != null ? dartRoot.path : gitRoot.path;
-    await GitUtils.commitVersion(
-      nextVersion,
-      commitRoot,
-      commitBadge: badge,
-      commitChangelog: generateChangelog,
-    );
+    await GitUtils.commitVersion(nextVersion, commitRoot, commitBadge: badge, commitChangelog: generateChangelog);
     logger.info('Committed version $nextVersion');
   }
 

--- a/lib/version/version_command.dart
+++ b/lib/version/version_command.dart
@@ -23,40 +23,16 @@ class VersionCommand extends Command
 
   @override
   String get usage {
-    return super.usage +
-        "\n\n"
-            "Calculates the next version based on API changes between versions.\n"
-            "Uses the current package version from the base file.\n";
+    return "${super.usage}\n\nCalculates the next version based on API changes between versions.\nUses the current package version from the base file.\n";
   }
 
   VersionCommand._internal() {
     argParser
-      ..addFlag(
-        'badge',
-        abbr: 'g',
-        help: 'Generate a badge for the version',
-      )
-      ..addFlag(
-        'commit',
-        help: 'Commit the version to git',
-        defaultsTo: true,
-      )
-      ..addFlag(
-        'tag',
-        abbr: 't',
-        help: 'Tag the version',
-        defaultsTo: true,
-      )
-      ..addFlag(
-        'generate-changelog',
-        help: 'Generate a changelog entry based on API changes',
-        defaultsTo: true,
-      )
-      ..addOption(
-        'json',
-        help: 'Output the result as JSON to the specified file',
-        valueHelp: 'file',
-      )
+      ..addFlag('badge', abbr: 'g', help: 'Generate a badge for the version')
+      ..addFlag('commit', help: 'Commit the version to git', defaultsTo: true)
+      ..addFlag('tag', abbr: 't', help: 'Tag the version', defaultsTo: true)
+      ..addFlag('generate-changelog', help: 'Generate a changelog entry based on API changes', defaultsTo: true)
+      ..addOption('json', help: 'Output the result as JSON to the specified file', valueHelp: 'file')
       ..addFlag(
         'pre-release',
         abbr: 'p',
@@ -75,11 +51,7 @@ class VersionCommand extends Command
         defaultsTo: 'v',
         valueHelp: 'prefix',
       )
-      ..addOption(
-        'dart-file',
-        help: 'Output the version as a Dart constant to the specified file',
-        valueHelp: 'file',
-      );
+      ..addOption('dart-file', help: 'Output the version as a Dart constant to the specified file', valueHelp: 'file');
   }
 
   bool get tag {

--- a/lib/version/version_workspace_command.dart
+++ b/lib/version/version_workspace_command.dart
@@ -26,42 +26,16 @@ class VersionWorkspaceCommand extends Command
 
   @override
   String get usage {
-    return super.usage +
-        "\n\n"
-            "Calculates the next version for each package in a Dart workspace based on API changes.\n"
-            "Only packages with changes compared to the base ref will be versioned.\n"
-            "Tags are created in format: {package-name}/v{version}\n"
-            "Dependencies between workspace packages are automatically updated.\n";
+    return "${super.usage}\n\nCalculates the next version for each package in a Dart workspace based on API changes.\nOnly packages with changes compared to the base ref will be versioned.\nTags are created in format: {package-name}/v{version}\nDependencies between workspace packages are automatically updated.\n";
   }
 
   VersionWorkspaceCommand._internal() {
     argParser
-      ..addFlag(
-        'badge',
-        abbr: 'g',
-        help: 'Generate a badge for the version',
-      )
-      ..addFlag(
-        'commit',
-        help: 'Commit the version to git',
-        defaultsTo: true,
-      )
-      ..addFlag(
-        'tag',
-        abbr: 't',
-        help: 'Tag the version',
-        defaultsTo: true,
-      )
-      ..addFlag(
-        'generate-changelog',
-        help: 'Generate a changelog entry based on API changes',
-        defaultsTo: true,
-      )
-      ..addOption(
-        'json',
-        help: 'Output the result as JSON to the specified file',
-        valueHelp: 'file',
-      )
+      ..addFlag('badge', abbr: 'g', help: 'Generate a badge for the version')
+      ..addFlag('commit', help: 'Commit the version to git', defaultsTo: true)
+      ..addFlag('tag', abbr: 't', help: 'Tag the version', defaultsTo: true)
+      ..addFlag('generate-changelog', help: 'Generate a changelog entry based on API changes', defaultsTo: true)
+      ..addOption('json', help: 'Output the result as JSON to the specified file', valueHelp: 'file')
       ..addFlag(
         'pre-release',
         abbr: 'p',
@@ -74,11 +48,7 @@ class VersionWorkspaceCommand extends Command
         defaultsTo: '',
         valueHelp: 'prefix',
       )
-      ..addOption(
-        'dart-file',
-        help: 'Output the version as a Dart constant to the specified file',
-        valueHelp: 'file',
-      );
+      ..addOption('dart-file', help: 'Output the version as a Dart constant to the specified file', valueHelp: 'file');
   }
 
   bool get tag {

--- a/lib/version/workspace_utils.dart
+++ b/lib/version/workspace_utils.dart
@@ -9,10 +9,7 @@ class WorkspaceInfo {
   final Directory root;
   final List<String> memberPaths;
 
-  WorkspaceInfo({
-    required this.root,
-    required this.memberPaths,
-  });
+  WorkspaceInfo({required this.root, required this.memberPaths});
 }
 
 class WorkspacePackage {
@@ -20,11 +17,7 @@ class WorkspacePackage {
   final Directory directory;
   final String relativePath;
 
-  WorkspacePackage({
-    required this.name,
-    required this.directory,
-    required this.relativePath,
-  });
+  WorkspacePackage({required this.name, required this.directory, required this.relativePath});
 }
 
 /// Detects if the given directory is a Dart workspace root
@@ -59,10 +52,7 @@ WorkspaceInfo? detectWorkspace(Directory root) {
       return null;
     }
 
-    return WorkspaceInfo(
-      root: root,
-      memberPaths: memberPaths,
-    );
+    return WorkspaceInfo(root: root, memberPaths: memberPaths);
   } catch (e) {
     logger.detail('Error detecting workspace: $e');
     return null;
@@ -75,8 +65,9 @@ List<WorkspacePackage> getWorkspacePackages(WorkspaceInfo workspace) {
 
   for (final memberPath in workspace.memberPaths) {
     // Resolve path relative to workspace root
-    final packageDir =
-        path.isAbsolute(memberPath) ? Directory(memberPath) : Directory(path.join(workspace.root.path, memberPath));
+    final packageDir = path.isAbsolute(memberPath)
+        ? Directory(memberPath)
+        : Directory(path.join(workspace.root.path, memberPath));
 
     if (!packageDir.existsSync()) {
       logger.warn('Workspace member path does not exist: ${packageDir.path}');
@@ -94,11 +85,7 @@ List<WorkspacePackage> getWorkspacePackages(WorkspaceInfo workspace) {
       final packageName = PubspecUtils.getPackageName(pubspecContent);
       final relativePath = path.relative(packageDir.path, from: workspace.root.path);
 
-      packages.add(WorkspacePackage(
-        name: packageName,
-        directory: packageDir,
-        relativePath: relativePath,
-      ));
+      packages.add(WorkspacePackage(name: packageName, directory: packageDir, relativePath: relativePath));
     } catch (e) {
       logger.warn('Error reading package name from ${packageDir.path}: $e');
       continue;
@@ -109,25 +96,16 @@ List<WorkspacePackage> getWorkspacePackages(WorkspaceInfo workspace) {
 }
 
 /// Checks if a package directory has changes between two git refs
-Future<bool> packageHasChanges(
-  String packagePath,
-  String baseRef,
-  String newRef,
-  Directory gitRoot,
-) async {
+Future<bool> packageHasChanges(String packagePath, String baseRef, String newRef, Directory gitRoot) async {
   try {
     // Use git diff to check if any files in the package directory changed
-    final result = await Process.run(
-      'git',
-      [
-        'diff',
-        '--name-only',
-        '$baseRef..$newRef',
-        '--',
-        packagePath,
-      ],
-      workingDirectory: gitRoot.path,
-    );
+    final result = await Process.run('git', [
+      'diff',
+      '--name-only',
+      '$baseRef..$newRef',
+      '--',
+      packagePath,
+    ], workingDirectory: gitRoot.path);
 
     if (result.exitCode != 0) {
       logger.warn('Git diff failed for package $packagePath: ${result.stderr}');

--- a/lib/version/workspace_version.dart
+++ b/lib/version/workspace_version.dart
@@ -12,15 +12,10 @@ class WorkspaceVersionResult {
   final Map<String, VersionResult> packageResults;
   final Map<String, Version> packageVersions;
 
-  WorkspaceVersionResult({
-    required this.packageResults,
-    required this.packageVersions,
-  });
+  WorkspaceVersionResult({required this.packageResults, required this.packageVersions});
 
   Map<String, dynamic> toJson() {
-    return {
-      'packages': packageResults.map((key, value) => MapEntry(key, value.toJson())),
-    };
+    return {'packages': packageResults.map((key, value) => MapEntry(key, value.toJson()))};
   }
 }
 
@@ -54,16 +49,12 @@ Future<WorkspaceVersionResult> versionWorkspace({
 
     // Determine the base ref for this package
     // If baseRef is provided, use it; otherwise get the previous tag for this package
-    final packageBaseRef = baseRef ??
+    final packageBaseRef =
+        baseRef ??
         (await GitUtils.getPreviousRefForPackage(gitRoot.path, package.name, tagPrefix: 'v') ?? effectiveNewRef);
 
     // Check if package has changes
-    final hasChanges = await packageHasChanges(
-      package.relativePath,
-      packageBaseRef,
-      effectiveNewRef,
-      gitRoot,
-    );
+    final hasChanges = await packageHasChanges(package.relativePath, packageBaseRef, effectiveNewRef, gitRoot);
 
     if (!hasChanges) {
       logger.info('Package ${package.name} has no changes, skipping versioning');
@@ -106,18 +97,11 @@ Future<WorkspaceVersionResult> versionWorkspace({
   // Step 2: Update dependencies between workspace packages
   if (packageVersions.isNotEmpty) {
     logger.info('Updating workspace dependencies...');
-    await updateWorkspaceDependencies(
-      workspace: workspace,
-      packages: packages,
-      updatedVersions: packageVersions,
-    );
+    await updateWorkspaceDependencies(workspace: workspace, packages: packages, updatedVersions: packageVersions);
     logger.success('Updated workspace dependencies');
   }
 
-  return WorkspaceVersionResult(
-    packageResults: packageResults,
-    packageVersions: packageVersions,
-  );
+  return WorkspaceVersionResult(packageResults: packageResults, packageVersions: packageVersions);
 }
 
 /// Updates dependencies in workspace packages that reference other workspace packages
@@ -162,11 +146,7 @@ Future<void> updateWorkspaceDependencies({
         // Check if this package depends on this workspace package
         if (dependencies.containsKey(dependencyName)) {
           try {
-            await PubspecUtils.updateWorkspaceDependency(
-              pubspecFile,
-              dependencyName,
-              newVersion,
-            );
+            await PubspecUtils.updateWorkspaceDependency(pubspecFile, dependencyName, newVersion);
             logger.info('Updated dependency $dependencyName to $newVersion in ${package.name}');
           } catch (e) {
             logger.warn('Failed to update dependency $dependencyName in ${package.name}: $e');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
   test: ^1.31.1
   json_serializable: ^6.14.0
   build_runner: ^2.15.0
-  flutter_lints: ^1.0.0
+  flutter_lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
   test: ^1.31.1
   json_serializable: ^6.14.0
   build_runner: ^2.15.0
-  flutter_lints: ^6.0.0
+  flutter_lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,15 +3,11 @@ description: A package to generate and compare API docs
 homepage: https://github.com/emdgroup/mtrust-api-guard/
 version: 6.0.7
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.11.0 <4.0.0"
 dependencies:
-  analyzer: ^7.4.5
-  build: ^2.4.1
-  code_builder: ^4.8.0
+  analyzer: ^13.3.0
   conventional: ^0.4.0
   glob: ^2.1.3
-  build_config: ^1.1.1
-  dart_style: ^3.1.0
   args: ^2.4.0
   path: ^1.9.1
   collection: ^1.19.1
@@ -19,14 +15,16 @@ dependencies:
   mason_logger: ^0.3.3
   pub_semver: ^2.2.0
   yaml_edit: ^2.2.2
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
   http: ^1.4.0
   crypto: ^3.0.7
   recase: ^4.1.0
 executables:
   mtrust_api_guard:
 dev_dependencies:
-  test: any
-  json_serializable: ^6.9.5
-  build_runner: ^2.4.15
-  flutter_lints: ^1.0.0
+  build: ^4.0.0
+  build_config: ^1.3.0
+  test: ^1.31.1
+  json_serializable: ^6.14.0
+  build_runner: ^2.15.0
+  flutter_lints: ^6.0.0

--- a/test/README.md
+++ b/test/README.md
@@ -7,44 +7,36 @@ This directory contains the test files for the mtrust-api-guard project, organiz
 ```
 test/
 ├── README.md                    # This file
-├── mtrust_api_guard_test.dart  # Main test runner
 ├── test_config.dart            # Global test configuration
 ├── helpers/                    # Common test utilities
+│   ├── test_bootstrap.dart    # Auto compile binary + Flutter scaffolds
 │   ├── test_helpers.dart      # Helper functions and constants
 │   └── test_setup.dart        # Test setup and teardown utilities
 └── commands/                   # Command-specific test files
-    ├── generate_command_test.dart  # Tests for the generate command
-    ├── compare_command_test.dart   # Tests for the compare command
-    └── version_command_test.dart   # Tests for the version command
+    ├── generate_command_test.dart
+    ├── compare_command_test.dart
+    └── version_command_test.dart
 ```
-
-## Test Organization
-
-### Main Test Runner
-- `mtrust_api_guard_test.dart` - Imports and runs all test files
-
-### Helper Files
-- `test_helpers.dart` - Contains common utility functions like `copyDir`, `runProcess`, and `stripChangelog`
-- `test_setup.dart` - Manages test environment setup, teardown, and common operations like git setup
-
-### Command Tests
-Each command has its own test file:
-- **Generate Command**: Tests API documentation generation functionality
-- **Compare Command**: Tests API comparison between different versions
-- **Version Command**: Tests version management and changelog generation
 
 ## Running Tests
 
-To run all tests:
+No manual setup is required. Integration tests bootstrap automatically on first `setUp()`:
+
+- Compiles `build/mtrust_api_guard` when missing or when `lib/` / `bin/` changed
+- Generates `.test_scaffolds/package_base/` and `plugin_base/` when missing (always on CI)
+
 ```bash
-dart test
+flutter test
 ```
 
-To run specific test files:
+`test/flutter_test_config.dart` bootstraps binaries and fixtures and removes any legacy scaffolds under `test/fixtures/` before tests run.
+
+To run specific integration test files:
+
 ```bash
-dart test test/commands/generate_command_test.dart
-dart test test/commands/compare_command_test.dart
-dart test test/commands/version_command_test.dart
+flutter test test/commands/generate_command_test.dart
+flutter test test/commands/compare_command_test.dart
+flutter test test/commands/version_command_test.dart
 ```
 
 ## Test Constants
@@ -57,9 +49,11 @@ Common test constants are defined in `TestConstants` class:
 ## Test Fixtures
 
 Test fixtures are managed through the `TestFixtures` class, which provides access to:
-- Different app versions for testing
+- Different app versions for testing (`app_v100`, `app_v101`, etc.)
+- Generated Flutter scaffolds (`package_base`, `plugin_base` in `.test_scaffolds/`) — not committed, created by bootstrap
 - Expected output files
-- Test data directories
+
+If scaffold drift occurs after a Flutter SDK upgrade locally, delete `.test_scaffolds/` and re-run tests.
 
 ## Benefits of This Structure
 

--- a/test/commands/compare_command_test.dart
+++ b/test/commands/compare_command_test.dart
@@ -111,8 +111,11 @@ void main() {
 
       // 6. Verify that no output file was created since only patch changes exist
       final outputFile = File(compareOutputFile);
-      expect(outputFile.existsSync(), isFalse,
-          reason: 'Output file should not be created when no relevant changes exist');
+      expect(
+        outputFile.existsSync(),
+        isFalse,
+        reason: 'Output file should not be created when no relevant changes exist',
+      );
 
       // 7. Run compare command with all magnitudes to verify changes do exist
       final compareOutputFileAll = p.join(testSetup.tempDir.path, 'compare_output_all.txt');

--- a/test/commands/generate_command_test.dart
+++ b/test/commands/generate_command_test.dart
@@ -35,9 +35,7 @@ void main() {
 
       if (!File(expectedGeneratedFilePath).existsSync()) {
         File(expectedGeneratedFilePath).createSync();
-        File(expectedGeneratedFilePath).writeAsStringSync(
-          await File(generatedFilePath).readAsString(),
-        );
+        File(expectedGeneratedFilePath).writeAsStringSync(await File(generatedFilePath).readAsString());
       }
 
       final expectedGeneratedContent = await File(expectedGeneratedFilePath).readAsString();
@@ -46,12 +44,12 @@ void main() {
       // decode the json to avoid formatting issues
       final expectedJson = jsonDecode(expectedGeneratedContent) as Map<String, dynamic>;
       final generatedJson = jsonDecode(generatedContent) as Map<String, dynamic>;
-      
+
       // Remove sdkVersion from both JSON objects to ignore SDK version differences
       // Different Flutter versions generate different SDK constraints
       final normalizedExpectedJson = removeSdkVersionFromJson(expectedJson);
       final normalizedGeneratedJson = removeSdkVersionFromJson(generatedJson);
-      
+
       expect(normalizedGeneratedJson, normalizedExpectedJson);
     });
   }, timeout: const Timeout(Duration(minutes: 5)));

--- a/test/commands/version_command_test.dart
+++ b/test/commands/version_command_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     /// Helper to update pubspec.yaml using YamlEditor
-    Future<void> _updatePubspec(String filePath, List<Object> path, dynamic value) async {
+    Future<void> updatePubspec(String filePath, List<Object> path, dynamic value) async {
       final pubspecFile = File(filePath);
       final pubspecContent = await pubspecFile.readAsString();
       final editor = YamlEditor(pubspecContent);
@@ -34,7 +34,7 @@ void main() {
     }
 
     /// Helper method to set up initial version state with homepage for changelog links
-    Future<void> _setupInitialVersion({bool plugin = false}) async {
+    Future<void> setupInitialVersion({bool plugin = false}) async {
       await testSetup.setupGitRepo();
       if (plugin) {
         await testSetup.setupFlutterPlugin();
@@ -44,11 +44,7 @@ void main() {
 
       // Add homepage to pubspec.yaml for testing changelog links
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
-      await _updatePubspec(
-        pubspecFile.path,
-        ['homepage'],
-        'https://github.com/emdgroup/mtrust-api-guard/',
-      );
+      await updatePubspec(pubspecFile.path, ['homepage'], 'https://github.com/emdgroup/mtrust-api-guard/');
 
       // Set up initial version
       await copyDir(testSetup.fixtures.appV100Dir, testSetup.tempDir);
@@ -61,7 +57,7 @@ void main() {
     }
 
     test('detects patch-level API changes', () async {
-      await _setupInitialVersion();
+      await setupInitialVersion();
 
       // Apply patch-level changes (0.0.0 -> 0.0.1)
       await copyDir(testSetup.fixtures.appV101Dir, testSetup.tempDir);
@@ -77,19 +73,14 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.patchVersion);
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.initialVersion}'));
       expect(tags, contains('v${TestConstants.patchVersion}'));
     });
 
     test('detects minor-level API changes', () async {
       printOnFailure("================================================");
-      await _setupInitialVersion();
+      await setupInitialVersion();
 
       // Apply patch-level changes first to get to 1.0.1
       await copyDir(testSetup.fixtures.appV101Dir, testSetup.tempDir);
@@ -113,17 +104,12 @@ void main() {
       printOnFailure("================================================");
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.minorVersion}'));
     });
 
     test('detects major-level API changes', () async {
-      await _setupInitialVersion();
+      await setupInitialVersion();
 
       // Apply patch-level changes first to get to 1.0.1
       await copyDir(testSetup.fixtures.appV101Dir, testSetup.tempDir);
@@ -144,17 +130,12 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.majorVersion);
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.majorVersion}'));
     });
 
     test('generates changelog correctly for multiple version changes', () async {
-      await _setupInitialVersion();
+      await setupInitialVersion();
 
       // Apply patch-level changes (1.0.0 -> 1.0.1)
       await copyDir(testSetup.fixtures.appV101Dir, testSetup.tempDir);
@@ -172,12 +153,7 @@ void main() {
       await testSetup.runApiGuard('version', ["--verbose"]);
 
       // Verify all version tags were created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.initialVersion}'));
       expect(tags, contains('v${TestConstants.patchVersion}'));
       expect(tags, contains('v${TestConstants.minorVersion}'));
@@ -185,9 +161,7 @@ void main() {
 
       // Verify changelog was generated correctly
       final changelogFile = File(p.join(testSetup.tempDir.path, 'CHANGELOG.md'));
-      final changelogContent = stripChangelog(
-        await changelogFile.readAsString(),
-      );
+      final changelogContent = stripChangelog(await changelogFile.readAsString());
       printOnFailure('Generated Changelog:\n$changelogContent');
 
       if (!testSetup.fixtures.expectedChangelogFile.existsSync()) {
@@ -195,19 +169,17 @@ void main() {
         testSetup.fixtures.expectedChangelogFile.writeAsStringSync(changelogContent);
       }
 
-      final expectedChangelog = stripChangelog(
-        await testSetup.fixtures.expectedChangelogFile.readAsString(),
-      );
+      final expectedChangelog = stripChangelog(await testSetup.fixtures.expectedChangelogFile.readAsString());
 
       expect(changelogContent, equalsIgnoringWhitespace(expectedChangelog));
     });
 
     test('detects version change when adding a dependency', () async {
-      await _setupInitialVersion();
+      await setupInitialVersion();
 
       // Add a dependency
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
-      await _updatePubspec(pubspecFile.path, ['dependencies', 'path'], '^1.8.0');
+      await updatePubspec(pubspecFile.path, ['dependencies', 'path'], '^1.8.0');
 
       await testSetup.commitChanges('chore: add path dependency');
       await testSetup.runApiGuard('version', ["--verbose"]);
@@ -217,21 +189,16 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.patchVersion);
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.patchVersion}'));
     });
 
     test('detects version change when removing a dependency', () async {
-      await _setupInitialVersion();
+      await setupInitialVersion();
 
       // First add a dependency
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
-      await _updatePubspec(pubspecFile.path, ['dependencies', 'path'], '^1.8.0');
+      await updatePubspec(pubspecFile.path, ['dependencies', 'path'], '^1.8.0');
       await testSetup.commitChanges('chore: add path dependency');
       await testSetup.runApiGuard('version', ["--verbose"]);
 
@@ -248,20 +215,15 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.minorVersion);
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.minorVersion}'));
     });
 
     test('detects patch version change when changing SDK constraints', () async {
-      await _setupInitialVersion(plugin: true);
+      await setupInitialVersion(plugin: true);
 
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
-      await _updatePubspec(pubspecFile.path, ['environment', 'sdk'], '>=3.2.0 <4.0.0');
+      await updatePubspec(pubspecFile.path, ['environment', 'sdk'], '>=3.2.0 <4.0.0');
 
       await testSetup.commitChanges('chore: update SDK constraints');
       await testSetup.runApiGuard('version', ["--verbose"]);
@@ -272,12 +234,7 @@ void main() {
       print(File(p.join(testSetup.tempDir.path, 'CHANGELOG.md')).readAsStringSync());
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.patchVersion}'));
     });
 
@@ -382,12 +339,7 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.patchVersion);
 
       // 3. Verify tag was created with custom prefix
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('release/${TestConstants.initialVersion}'));
       expect(tags, contains('release/${TestConstants.patchVersion}'));
       expect(tags, isNot(contains('v${TestConstants.patchVersion}')));

--- a/test/commands/version_plugin_command_test.dart
+++ b/test/commands/version_plugin_command_test.dart
@@ -23,7 +23,7 @@ void main() {
     });
 
     /// Helper to update pubspec.yaml using YamlEditor
-    Future<void> _updatePubspec(String filePath, List<Object> path, dynamic value) async {
+    Future<void> updatePubspec(String filePath, List<Object> path, dynamic value) async {
       final pubspecFile = File(filePath);
       final pubspecContent = await pubspecFile.readAsString();
       final editor = YamlEditor(pubspecContent);
@@ -33,25 +33,21 @@ void main() {
 
     /// Common setup helper: Initialize git repo, Flutter plugin, add homepage, and set up initial version
     /// Returns before committing so tests can add their constraint files first
-    Future<void> _setupPluginBase() async {
+    Future<void> setupPluginBase() async {
       // Initialize git repo and flutter plugin
       await testSetup.setupGitRepo();
       await testSetup.setupFlutterPlugin();
 
       // Add homepage to pubspec.yaml for testing changelog links
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
-      await _updatePubspec(
-        pubspecFile.path,
-        ['homepage'],
-        'https://github.com/emdgroup/mtrust-api-guard/',
-      );
+      await updatePubspec(pubspecFile.path, ['homepage'], 'https://github.com/emdgroup/mtrust-api-guard/');
 
       // Set up initial version 0.0.1 with initial API
       await copyDir(testSetup.fixtures.appV100Dir, testSetup.tempDir);
     }
 
     /// Helper to verify version bump and changelog
-    Future<void> _verifyVersionBumpAndChangelog({
+    Future<void> verifyVersionBumpAndChangelog({
       required String expectedChangelogText,
       String? additionalChangelogText,
     }) async {
@@ -60,12 +56,7 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.majorVersion);
 
       // Verify tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('v${TestConstants.initialVersion}'));
       expect(tags, contains('v${TestConstants.majorVersion}'));
 
@@ -85,15 +76,11 @@ void main() {
     }
 
     test('detects Dart SDK constraint changes as breaking changes in plugins', () async {
-      await _setupPluginBase();
+      await setupPluginBase();
 
       // Set up initial Dart SDK constraint in pubspec.yaml
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
-      await _updatePubspec(
-        pubspecFile.path,
-        ['environment', 'sdk'],
-        '^2.12.0',
-      );
+      await updatePubspec(pubspecFile.path, ['environment', 'sdk'], '^2.12.0');
 
       // Commit initial state with Dart SDK constraint and tag it
       await testSetup.commitChanges('chore!: Initial release v${TestConstants.initialVersion}');
@@ -101,53 +88,41 @@ void main() {
       expect(testSetup.getCurrentVersion(), TestConstants.initialVersion);
 
       // Change Dart SDK constraint from ^2.12.0 to ^3.0.0
-      await _updatePubspec(
-        pubspecFile.path,
-        ['environment', 'sdk'],
-        '^3.0.0',
-      );
+      await updatePubspec(pubspecFile.path, ['environment', 'sdk'], '^3.0.0');
 
       await testSetup.commitChanges('feat: increase Dart SDK constraint to ^3.0.0');
 
-      await _verifyVersionBumpAndChangelog(
+      await verifyVersionBumpAndChangelog(
         expectedChangelogText: '🎯 Minimum Dart SDK version increased:',
         additionalChangelogText: 'from `^2.12.0` to `^3.0.0`',
       );
     });
 
     test('detects Flutter constraint changes as breaking changes in plugins', () async {
-      await _setupPluginBase();
+      await setupPluginBase();
 
       // Set up initial Flutter constraint in pubspec.yaml
       final pubspecFile = File(p.join(testSetup.tempDir.path, 'pubspec.yaml'));
 
-      await _updatePubspec(
-        pubspecFile.path,
-        ['environment', 'flutter'],
-        '^3.0.0',
-      );
+      await updatePubspec(pubspecFile.path, ['environment', 'flutter'], '^3.0.0');
 
       // Commit initial state with Flutter constraint and tag it
       await testSetup.commitChanges('chore!: Initial release v${TestConstants.initialVersion}');
       await runProcess('git', ['tag', 'v${TestConstants.initialVersion}'], workingDir: testSetup.tempDir.path);
       expect(testSetup.getCurrentVersion(), TestConstants.initialVersion);
 
-      await _updatePubspec(
-        pubspecFile.path,
-        ['environment', 'flutter'],
-        '^3.5.0',
-      );
+      await updatePubspec(pubspecFile.path, ['environment', 'flutter'], '^3.5.0');
 
       await testSetup.commitChanges('feat: increase Flutter constraint to ^3.5.0');
 
-      await _verifyVersionBumpAndChangelog(
+      await verifyVersionBumpAndChangelog(
         expectedChangelogText: '🎯 Minimum Flutter SDK version increased:',
         additionalChangelogText: 'from `^3.0.0` to `^3.5.0`',
       );
     });
 
     test('detects Android constraint changes as breaking changes in plugins', () async {
-      await _setupPluginBase();
+      await setupPluginBase();
 
       // Create initial Android build.gradle file for plugin (android/build.gradle)
       final androidDir = Directory(p.join(testSetup.tempDir.path, 'android'));
@@ -231,14 +206,14 @@ android {
 
       await testSetup.commitChanges('feat: increase Android minSdkVersion to 21');
 
-      await _verifyVersionBumpAndChangelog(
+      await verifyVersionBumpAndChangelog(
         expectedChangelogText: '🤖 Minimum Android SDK version increased:',
         additionalChangelogText: 'from `19` to `21`',
       );
     });
 
     test('detects iOS constraint changes as breaking changes in plugins', () async {
-      await _setupPluginBase();
+      await setupPluginBase();
 
       // Create initial iOS .podspec file with platform version
       final iosDir = Directory(p.join(testSetup.tempDir.path, 'ios'));
@@ -282,7 +257,7 @@ end
 
       await testSetup.commitChanges('feat: increase iOS minimum OS version to 13.0');
 
-      await _verifyVersionBumpAndChangelog(
+      await verifyVersionBumpAndChangelog(
         expectedChangelogText: '🍎 Minimum iOS SDK version increased:',
         additionalChangelogText: 'from `12.0` to `13.0`',
       );

--- a/test/commands/version_workspace_command_test.dart
+++ b/test/commands/version_workspace_command_test.dart
@@ -32,6 +32,35 @@ void main() {
       await pubspecFile.writeAsString(editor.toString());
     }
 
+    Future<Directory> setupWorkspacePackage({
+      required String packageName,
+      required String version,
+      Map<String, String>? dependencies,
+    }) async {
+      final packageDir = Directory(p.join(testSetup.tempDir.path, 'packages', packageName));
+      await packageDir.create(recursive: true);
+      await copyPackageBase(packageDir, packageName: packageName);
+
+      final pubspecFile = File(p.join(packageDir.path, 'pubspec.yaml'));
+      await updatePubspec(pubspecFile.path, ['version'], version);
+      await updatePubspec(pubspecFile.path, ['resolution'], 'workspace');
+
+      for (final entry in dependencies?.entries ?? const <MapEntry<String, String>>[]) {
+        await updatePubspec(pubspecFile.path, ['dependencies', entry.key], entry.value);
+      }
+
+      final libDir = Directory(p.join(packageDir.path, 'lib'));
+      await libDir.create(recursive: true);
+      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), libDir);
+
+      final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
+      if (v100AnalysisOptions.existsSync()) {
+        await v100AnalysisOptions.copy(p.join(packageDir.path, 'analysis_options.yaml'));
+      }
+
+      return packageDir;
+    }
+
     test('versions workspace packages with changes and updates dependencies', () async {
       // 1. Initialize git repo
       await testSetup.setupGitRepo();
@@ -48,53 +77,15 @@ workspace:
 ''');
 
       // 3. Create shared package
-      final sharedDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'shared'));
-      await sharedDir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: sharedDir.path);
-
-      // Clear lib and test directories
-      await Directory(p.join(sharedDir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(sharedDir.path, 'lib')).create();
-      await Directory(p.join(sharedDir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(sharedDir.path, 'test')).create();
-
-      // Update shared package pubspec.yaml
-      final sharedPubspec = File(p.join(sharedDir.path, 'pubspec.yaml'));
-      await updatePubspec(sharedPubspec.path, ['version'], '0.0.1');
-      await updatePubspec(sharedPubspec.path, ['resolution'], 'workspace');
-
-      // Copy API files to shared package
+      final sharedDir = await setupWorkspacePackage(packageName: 'shared', version: '0.0.1');
       final sharedLibDir = Directory(p.join(sharedDir.path, 'lib'));
-      await sharedLibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), sharedLibDir);
-
-      // Copy analysis_options.yaml from fixtures to ensure consistent entry points
-      final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
-      if (v100AnalysisOptions.existsSync()) {
-        await v100AnalysisOptions.copy(p.join(sharedDir.path, 'analysis_options.yaml'));
-      }
 
       // 4. Create consumer package that depends on shared
-      final consumerDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'consumer'));
-      await consumerDir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: consumerDir.path);
-
-      // Clear lib and test directories
-      await Directory(p.join(consumerDir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(consumerDir.path, 'lib')).create();
-      await Directory(p.join(consumerDir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(consumerDir.path, 'test')).create();
-
-      // Update consumer package pubspec.yaml
-      final consumerPubspec = File(p.join(consumerDir.path, 'pubspec.yaml'));
-      await updatePubspec(consumerPubspec.path, ['version'], '0.0.1');
-      await updatePubspec(consumerPubspec.path, ['resolution'], 'workspace');
-      await updatePubspec(consumerPubspec.path, ['dependencies', 'shared'], '^0.0.1');
-
-      // Copy API files to consumer package
-      final consumerLibDir = Directory(p.join(consumerDir.path, 'lib'));
-      await consumerLibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), consumerLibDir);
+      await setupWorkspacePackage(
+        packageName: 'consumer',
+        version: '0.0.1',
+        dependencies: {'shared': '^0.0.1'},
+      );
 
       // 5. Commit initial state
       await testSetup.commitChanges('chore!: Initial workspace setup');
@@ -124,6 +115,7 @@ workspace:
       expect(sharedPubspecYaml['version'], '0.0.2');
 
       // 11. Verify consumer package was NOT versioned (no changes)
+      final consumerDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'consumer'));
       final consumerPubspecAfter = File(p.join(consumerDir.path, 'pubspec.yaml'));
       final consumerPubspecYaml = loadYaml(await consumerPubspecAfter.readAsString()) as YamlMap;
       expect(consumerPubspecYaml['version'], '0.0.1');
@@ -161,46 +153,11 @@ workspace:
 ''');
 
       // 3. Create package_a
-      final packageADir = Directory(p.join(testSetup.tempDir.path, 'packages', 'package_a'));
-      await packageADir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: packageADir.path);
-
-      await Directory(p.join(packageADir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(packageADir.path, 'lib')).create();
-      await Directory(p.join(packageADir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(packageADir.path, 'test')).create();
-
-      final packageAPubspec = File(p.join(packageADir.path, 'pubspec.yaml'));
-      await updatePubspec(packageAPubspec.path, ['version'], '0.0.1');
-      await updatePubspec(packageAPubspec.path, ['resolution'], 'workspace');
-
+      final packageADir = await setupWorkspacePackage(packageName: 'package_a', version: '0.0.1');
       final packageALibDir = Directory(p.join(packageADir.path, 'lib'));
-      await packageALibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), packageALibDir);
-
-      // Copy analysis_options.yaml from fixtures to ensure consistent entry points
-      final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
-      if (v100AnalysisOptions.existsSync()) {
-        await v100AnalysisOptions.copy(p.join(packageADir.path, 'analysis_options.yaml'));
-      }
 
       // 4. Create package_b
-      final packageBDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'package_b'));
-      await packageBDir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: packageBDir.path);
-
-      await Directory(p.join(packageBDir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(packageBDir.path, 'lib')).create();
-      await Directory(p.join(packageBDir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(packageBDir.path, 'test')).create();
-
-      final packageBPubspec = File(p.join(packageBDir.path, 'pubspec.yaml'));
-      await updatePubspec(packageBPubspec.path, ['version'], '0.0.1');
-      await updatePubspec(packageBPubspec.path, ['resolution'], 'workspace');
-
-      final packageBLibDir = Directory(p.join(packageBDir.path, 'lib'));
-      await packageBLibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), packageBLibDir);
+      await setupWorkspacePackage(packageName: 'package_b', version: '0.0.1');
 
       // 5. Commit initial state
       await testSetup.commitChanges('chore!: Initial workspace setup');
@@ -227,6 +184,7 @@ workspace:
       expect(packageAPubspecYaml['version'], '0.0.2');
 
       // 9. Verify package_b was NOT versioned
+      final packageBDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'package_b'));
       final packageBPubspecAfter = File(p.join(packageBDir.path, 'pubspec.yaml'));
       final packageBPubspecYaml = loadYaml(await packageBPubspecAfter.readAsString()) as YamlMap;
       expect(packageBPubspecYaml['version'], '0.0.1');
@@ -269,75 +227,22 @@ workspace:
 ''');
 
       // 3. Create base package
-      final baseDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'base'));
-      await baseDir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: baseDir.path);
-      await Directory(p.join(baseDir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(baseDir.path, 'lib')).create();
-      await Directory(p.join(baseDir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(baseDir.path, 'test')).create();
-
-      final basePubspec = File(p.join(baseDir.path, 'pubspec.yaml'));
-      await updatePubspec(basePubspec.path, ['version'], '0.0.1');
-      await updatePubspec(basePubspec.path, ['resolution'], 'workspace');
-
+      final baseDir = await setupWorkspacePackage(packageName: 'base', version: '0.0.1');
       final baseLibDir = Directory(p.join(baseDir.path, 'lib'));
-      await baseLibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), baseLibDir);
-
-      // Copy analysis_options.yaml from fixtures to ensure consistent entry points
-      final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
-      if (v100AnalysisOptions.existsSync()) {
-        await v100AnalysisOptions.copy(p.join(baseDir.path, 'analysis_options.yaml'));
-      }
 
       // 4. Create shared package (depends on base)
-      final sharedDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'shared'));
-      await sharedDir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: sharedDir.path);
-      await Directory(p.join(sharedDir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(sharedDir.path, 'lib')).create();
-      await Directory(p.join(sharedDir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(sharedDir.path, 'test')).create();
-
-      final sharedPubspec = File(p.join(sharedDir.path, 'pubspec.yaml'));
-      await updatePubspec(sharedPubspec.path, ['version'], '0.0.1');
-      await updatePubspec(sharedPubspec.path, ['resolution'], 'workspace');
-      await updatePubspec(sharedPubspec.path, ['dependencies', 'base'], '^0.0.1');
-
-      final sharedLibDir = Directory(p.join(sharedDir.path, 'lib'));
-      await sharedLibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), sharedLibDir);
-
-      // Copy analysis_options.yaml from fixtures to ensure consistent entry points
-      final v100AnalysisOptionsShared = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
-      if (v100AnalysisOptionsShared.existsSync()) {
-        await v100AnalysisOptionsShared.copy(p.join(sharedDir.path, 'analysis_options.yaml'));
-      }
+      await setupWorkspacePackage(
+        packageName: 'shared',
+        version: '0.0.1',
+        dependencies: {'base': '^0.0.1'},
+      );
 
       // 5. Create consumer package (depends on shared)
-      final consumerDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'consumer'));
-      await consumerDir.create(recursive: true);
-      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: consumerDir.path);
-      await Directory(p.join(consumerDir.path, 'lib')).delete(recursive: true);
-      await Directory(p.join(consumerDir.path, 'lib')).create();
-      await Directory(p.join(consumerDir.path, 'test')).delete(recursive: true);
-      await Directory(p.join(consumerDir.path, 'test')).create();
-
-      final consumerPubspec = File(p.join(consumerDir.path, 'pubspec.yaml'));
-      await updatePubspec(consumerPubspec.path, ['version'], '0.0.1');
-      await updatePubspec(consumerPubspec.path, ['resolution'], 'workspace');
-      await updatePubspec(consumerPubspec.path, ['dependencies', 'shared'], '^0.0.1');
-
-      final consumerLibDir = Directory(p.join(consumerDir.path, 'lib'));
-      await consumerLibDir.create(recursive: true);
-      await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), consumerLibDir);
-
-      // Copy analysis_options.yaml from fixtures to ensure consistent entry points
-      final v100AnalysisOptionsConsumer = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
-      if (v100AnalysisOptionsConsumer.existsSync()) {
-        await v100AnalysisOptionsConsumer.copy(p.join(consumerDir.path, 'analysis_options.yaml'));
-      }
+      await setupWorkspacePackage(
+        packageName: 'consumer',
+        version: '0.0.1',
+        dependencies: {'shared': '^0.0.1'},
+      );
 
       // 6. Commit initial state
       await testSetup.commitChanges('chore!: Initial workspace setup');
@@ -365,6 +270,7 @@ workspace:
       expect(basePubspecYaml['version'], '0.1.0');
 
       // 10. Verify shared dependency on base was updated
+      final sharedDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'shared'));
       final sharedPubspecAfter = File(p.join(sharedDir.path, 'pubspec.yaml'));
       final sharedPubspecYaml = loadYaml(await sharedPubspecAfter.readAsString()) as YamlMap;
       final sharedDeps = sharedPubspecYaml['dependencies'] as YamlMap;
@@ -374,6 +280,7 @@ workspace:
       }
 
       // 11. Verify consumer dependency on shared was NOT updated (shared didn't change)
+      final consumerDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'consumer'));
       final consumerPubspecAfter = File(p.join(consumerDir.path, 'pubspec.yaml'));
       final consumerPubspecYaml = loadYaml(await consumerPubspecAfter.readAsString()) as YamlMap;
       final consumerDeps = consumerPubspecYaml['dependencies'] as YamlMap;

--- a/test/commands/version_workspace_command_test.dart
+++ b/test/commands/version_workspace_command_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
 
     /// Helper to update pubspec.yaml using YamlEditor
-    Future<void> _updatePubspec(String filePath, List<Object> path, dynamic value) async {
+    Future<void> updatePubspec(String filePath, List<Object> path, dynamic value) async {
       final pubspecFile = File(filePath);
       final pubspecContent = await pubspecFile.readAsString();
       final editor = YamlEditor(pubspecContent);
@@ -50,11 +50,7 @@ workspace:
       // 3. Create shared package
       final sharedDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'shared'));
       await sharedDir.create(recursive: true);
-      await runProcess(
-        'flutter',
-        ['create', '.', '--template', 'package'],
-        workingDir: sharedDir.path,
-      );
+      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: sharedDir.path);
 
       // Clear lib and test directories
       await Directory(p.join(sharedDir.path, 'lib')).delete(recursive: true);
@@ -64,14 +60,14 @@ workspace:
 
       // Update shared package pubspec.yaml
       final sharedPubspec = File(p.join(sharedDir.path, 'pubspec.yaml'));
-      await _updatePubspec(sharedPubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(sharedPubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(sharedPubspec.path, ['version'], '0.0.1');
+      await updatePubspec(sharedPubspec.path, ['resolution'], 'workspace');
 
       // Copy API files to shared package
       final sharedLibDir = Directory(p.join(sharedDir.path, 'lib'));
       await sharedLibDir.create(recursive: true);
       await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), sharedLibDir);
-      
+
       // Copy analysis_options.yaml from fixtures to ensure consistent entry points
       final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
       if (v100AnalysisOptions.existsSync()) {
@@ -81,11 +77,7 @@ workspace:
       // 4. Create consumer package that depends on shared
       final consumerDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'consumer'));
       await consumerDir.create(recursive: true);
-      await runProcess(
-        'flutter',
-        ['create', '.', '--template', 'package'],
-        workingDir: consumerDir.path,
-      );
+      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: consumerDir.path);
 
       // Clear lib and test directories
       await Directory(p.join(consumerDir.path, 'lib')).delete(recursive: true);
@@ -95,9 +87,9 @@ workspace:
 
       // Update consumer package pubspec.yaml
       final consumerPubspec = File(p.join(consumerDir.path, 'pubspec.yaml'));
-      await _updatePubspec(consumerPubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(consumerPubspec.path, ['resolution'], 'workspace');
-      await _updatePubspec(consumerPubspec.path, ['dependencies', 'shared'], '^0.0.1');
+      await updatePubspec(consumerPubspec.path, ['version'], '0.0.1');
+      await updatePubspec(consumerPubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(consumerPubspec.path, ['dependencies', 'shared'], '^0.0.1');
 
       // Copy API files to consumer package
       final consumerLibDir = Directory(p.join(consumerDir.path, 'lib'));
@@ -113,7 +105,7 @@ workspace:
 
       // 7. Make changes only to shared package (patch-level change)
       await copyDir(Directory(p.join(testSetup.fixtures.appV101Dir.path, 'lib')), sharedLibDir);
-      
+
       // Copy analysis_options.yaml from v101 fixtures to ensure consistent entry points
       final v101AnalysisOptions = File(p.join(testSetup.fixtures.appV101Dir.path, 'analysis_options.yaml'));
       if (v101AnalysisOptions.existsSync()) {
@@ -137,12 +129,7 @@ workspace:
       expect(consumerPubspecYaml['version'], '0.0.1');
 
       // 12. Verify tags were created correctly
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('shared/v0.0.1'));
       expect(tags, contains('shared/v0.0.2'));
       expect(tags, contains('consumer/v0.0.1'));
@@ -176,11 +163,7 @@ workspace:
       // 3. Create package_a
       final packageADir = Directory(p.join(testSetup.tempDir.path, 'packages', 'package_a'));
       await packageADir.create(recursive: true);
-      await runProcess(
-        'flutter',
-        ['create', '.', '--template', 'package'],
-        workingDir: packageADir.path,
-      );
+      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: packageADir.path);
 
       await Directory(p.join(packageADir.path, 'lib')).delete(recursive: true);
       await Directory(p.join(packageADir.path, 'lib')).create();
@@ -188,13 +171,13 @@ workspace:
       await Directory(p.join(packageADir.path, 'test')).create();
 
       final packageAPubspec = File(p.join(packageADir.path, 'pubspec.yaml'));
-      await _updatePubspec(packageAPubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(packageAPubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(packageAPubspec.path, ['version'], '0.0.1');
+      await updatePubspec(packageAPubspec.path, ['resolution'], 'workspace');
 
       final packageALibDir = Directory(p.join(packageADir.path, 'lib'));
       await packageALibDir.create(recursive: true);
       await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), packageALibDir);
-      
+
       // Copy analysis_options.yaml from fixtures to ensure consistent entry points
       final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
       if (v100AnalysisOptions.existsSync()) {
@@ -204,11 +187,7 @@ workspace:
       // 4. Create package_b
       final packageBDir = Directory(p.join(testSetup.tempDir.path, 'packages', 'package_b'));
       await packageBDir.create(recursive: true);
-      await runProcess(
-        'flutter',
-        ['create', '.', '--template', 'package'],
-        workingDir: packageBDir.path,
-      );
+      await runProcess('flutter', ['create', '.', '--template', 'package'], workingDir: packageBDir.path);
 
       await Directory(p.join(packageBDir.path, 'lib')).delete(recursive: true);
       await Directory(p.join(packageBDir.path, 'lib')).create();
@@ -216,8 +195,8 @@ workspace:
       await Directory(p.join(packageBDir.path, 'test')).create();
 
       final packageBPubspec = File(p.join(packageBDir.path, 'pubspec.yaml'));
-      await _updatePubspec(packageBPubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(packageBPubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(packageBPubspec.path, ['version'], '0.0.1');
+      await updatePubspec(packageBPubspec.path, ['resolution'], 'workspace');
 
       final packageBLibDir = Directory(p.join(packageBDir.path, 'lib'));
       await packageBLibDir.create(recursive: true);
@@ -230,13 +209,13 @@ workspace:
 
       // 6. Make changes only to package_a
       await copyDir(Directory(p.join(testSetup.fixtures.appV101Dir.path, 'lib')), packageALibDir);
-      
+
       // Copy analysis_options.yaml from v101 fixtures to ensure consistent entry points
       final v101AnalysisOptions = File(p.join(testSetup.fixtures.appV101Dir.path, 'analysis_options.yaml'));
       if (v101AnalysisOptions.existsSync()) {
         await v101AnalysisOptions.copy(p.join(packageADir.path, 'analysis_options.yaml'));
       }
-      
+
       await testSetup.commitChanges('fix: update package_a');
 
       // 7. Run version-workspace command
@@ -253,12 +232,7 @@ workspace:
       expect(packageBPubspecYaml['version'], '0.0.1');
 
       // 10. Verify only package_a tag was created
-      final tags = await runProcess(
-        'git',
-        ['tag'],
-        workingDir: testSetup.tempDir.path,
-        captureOutput: true,
-      );
+      final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
       expect(tags, contains('package_a/v0.0.2'));
       expect(tags, isNot(contains('package_b/v0.0.2')));
     });
@@ -275,10 +249,7 @@ workspace:
       await testSetup.commitChanges('chore!: Initial release');
 
       // 4. Attempt to run version-workspace command (should fail)
-      expect(
-        () async => await testSetup.runApiGuard('version-workspace', []),
-        throwsA(isA<Exception>()),
-      );
+      expect(() async => await testSetup.runApiGuard('version-workspace', []), throwsA(isA<Exception>()));
     });
 
     test('handles multiple packages with dependencies correctly', () async {
@@ -307,13 +278,13 @@ workspace:
       await Directory(p.join(baseDir.path, 'test')).create();
 
       final basePubspec = File(p.join(baseDir.path, 'pubspec.yaml'));
-      await _updatePubspec(basePubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(basePubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(basePubspec.path, ['version'], '0.0.1');
+      await updatePubspec(basePubspec.path, ['resolution'], 'workspace');
 
       final baseLibDir = Directory(p.join(baseDir.path, 'lib'));
       await baseLibDir.create(recursive: true);
       await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), baseLibDir);
-      
+
       // Copy analysis_options.yaml from fixtures to ensure consistent entry points
       final v100AnalysisOptions = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
       if (v100AnalysisOptions.existsSync()) {
@@ -330,14 +301,14 @@ workspace:
       await Directory(p.join(sharedDir.path, 'test')).create();
 
       final sharedPubspec = File(p.join(sharedDir.path, 'pubspec.yaml'));
-      await _updatePubspec(sharedPubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(sharedPubspec.path, ['resolution'], 'workspace');
-      await _updatePubspec(sharedPubspec.path, ['dependencies', 'base'], '^0.0.1');
+      await updatePubspec(sharedPubspec.path, ['version'], '0.0.1');
+      await updatePubspec(sharedPubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(sharedPubspec.path, ['dependencies', 'base'], '^0.0.1');
 
       final sharedLibDir = Directory(p.join(sharedDir.path, 'lib'));
       await sharedLibDir.create(recursive: true);
       await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), sharedLibDir);
-      
+
       // Copy analysis_options.yaml from fixtures to ensure consistent entry points
       final v100AnalysisOptionsShared = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
       if (v100AnalysisOptionsShared.existsSync()) {
@@ -354,14 +325,14 @@ workspace:
       await Directory(p.join(consumerDir.path, 'test')).create();
 
       final consumerPubspec = File(p.join(consumerDir.path, 'pubspec.yaml'));
-      await _updatePubspec(consumerPubspec.path, ['version'], '0.0.1');
-      await _updatePubspec(consumerPubspec.path, ['resolution'], 'workspace');
-      await _updatePubspec(consumerPubspec.path, ['dependencies', 'shared'], '^0.0.1');
+      await updatePubspec(consumerPubspec.path, ['version'], '0.0.1');
+      await updatePubspec(consumerPubspec.path, ['resolution'], 'workspace');
+      await updatePubspec(consumerPubspec.path, ['dependencies', 'shared'], '^0.0.1');
 
       final consumerLibDir = Directory(p.join(consumerDir.path, 'lib'));
       await consumerLibDir.create(recursive: true);
       await copyDir(Directory(p.join(testSetup.fixtures.appV100Dir.path, 'lib')), consumerLibDir);
-      
+
       // Copy analysis_options.yaml from fixtures to ensure consistent entry points
       final v100AnalysisOptionsConsumer = File(p.join(testSetup.fixtures.appV100Dir.path, 'analysis_options.yaml'));
       if (v100AnalysisOptionsConsumer.existsSync()) {
@@ -376,13 +347,13 @@ workspace:
 
       // 7. Make changes to base package (minor change)
       await copyDir(Directory(p.join(testSetup.fixtures.appV110Dir.path, 'lib')), baseLibDir);
-      
+
       // Copy analysis_options.yaml from v110 fixtures to ensure consistent entry points
       final v110AnalysisOptions = File(p.join(testSetup.fixtures.appV110Dir.path, 'analysis_options.yaml'));
       if (v110AnalysisOptions.existsSync()) {
         await v110AnalysisOptions.copy(p.join(baseDir.path, 'analysis_options.yaml'));
       }
-      
+
       await testSetup.commitChanges('feat: update base package');
 
       // 8. Run version-workspace command

--- a/test/comparators/apply_overrides_test.dart
+++ b/test/comparators/apply_overrides_test.dart
@@ -55,18 +55,10 @@ PropertyApiChange _propertyChange(DocComponent component) {
 }
 
 ApiGuardConfig _config(List<MagnitudeOverride> overrides) {
-  return ApiGuardConfig(
-    include: {'lib/**.dart'},
-    exclude: {},
-    generateBadge: false,
-    magnitudeOverrides: overrides,
-  );
+  return ApiGuardConfig(include: {'lib/**.dart'}, exclude: {}, generateBadge: false, magnitudeOverrides: overrides);
 }
 
-MagnitudeOverride _fromPackageOverride(
-  List<String> packages, {
-  String magnitude = 'ignore',
-}) {
+MagnitudeOverride _fromPackageOverride(List<String> packages, {String magnitude = 'ignore'}) {
   return MagnitudeOverride(
     operations: ['*'],
     magnitude: magnitude,
@@ -88,7 +80,7 @@ void main() {
         );
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['patrol'])
+          _fromPackageOverride(['patrol']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -97,12 +89,10 @@ void main() {
       });
 
       test('matches when filePath has multiple path segments in the package', () {
-        final component = _component(
-          filePath: 'package:some_pkg/src/deep/nested/file.dart',
-        );
+        final component = _component(filePath: 'package:some_pkg/src/deep/nested/file.dart');
         final change = _componentChange(component);
         final config = _config([
-          _fromPackageOverride(['some_pkg'])
+          _fromPackageOverride(['some_pkg']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -111,12 +101,10 @@ void main() {
       });
 
       test('does NOT match a different package name', () {
-        final component = _component(
-          filePath: 'package:patrol/src/platform/contracts/contracts.dart',
-        );
+        final component = _component(filePath: 'package:patrol/src/platform/contracts/contracts.dart');
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['other_package'])
+          _fromPackageOverride(['other_package']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -126,12 +114,10 @@ void main() {
       });
 
       test('does NOT match a component with a relative (project-owned) filePath', () {
-        final component = _component(
-          filePath: 'lib/src/my_class.dart',
-        );
+        final component = _component(filePath: 'lib/src/my_class.dart');
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['patrol'])
+          _fromPackageOverride(['patrol']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -143,7 +129,7 @@ void main() {
         final component = _component(filePath: null);
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['patrol'])
+          _fromPackageOverride(['patrol']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -152,12 +138,10 @@ void main() {
       });
 
       test('matches any of multiple packages listed', () {
-        final component = _component(
-          filePath: 'package:patrol_finders/src/finder.dart',
-        );
+        final component = _component(filePath: 'package:patrol_finders/src/finder.dart');
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['patrol', 'patrol_finders'])
+          _fromPackageOverride(['patrol', 'patrol_finders']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -166,12 +150,10 @@ void main() {
       });
 
       test('can downgrade (not just ignore) a change from an external package', () {
-        final component = _component(
-          filePath: 'package:patrol/src/platform/contracts/contracts.dart',
-        );
+        final component = _component(filePath: 'package:patrol/src/platform/contracts/contracts.dart');
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['patrol'], magnitude: 'patch')
+          _fromPackageOverride(['patrol'], magnitude: 'patch'),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -192,9 +174,7 @@ void main() {
         final override = MagnitudeOverride(
           operations: ['*'],
           magnitude: 'ignore',
-          selection: OverrideSelection(
-            enclosing: OverrideSelection(fromPackage: ['patrol']),
-          ),
+          selection: OverrideSelection(enclosing: OverrideSelection(fromPackage: ['patrol'])),
         );
         final config = _config([override]);
 
@@ -213,7 +193,7 @@ void main() {
         );
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
-          _fromPackageOverride(['flutter'])
+          _fromPackageOverride(['flutter']),
         ]);
 
         applyMagnitudeOverrides([change], config);
@@ -235,9 +215,7 @@ void main() {
       });
 
       test('first matching override wins, subsequent overrides are skipped', () {
-        final component = _component(
-          filePath: 'package:patrol/src/contracts.dart',
-        );
+        final component = _component(filePath: 'package:patrol/src/contracts.dart');
         final change = _componentChange(component, operation: ApiChangeOperation.removal);
         final config = _config([
           _fromPackageOverride(['patrol'], magnitude: 'patch'),

--- a/test/comparators/metadata_comparator_test.dart
+++ b/test/comparators/metadata_comparator_test.dart
@@ -12,9 +12,7 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes.length, greaterThanOrEqualTo(1));
-        final minIncrease = changes.firstWhere(
-          (c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease,
-        );
+        final minIncrease = changes.firstWhere((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease);
         expect(minIncrease.getMagnitude(), ApiChangeMagnitude.major);
         expect(minIncrease.changedValue, contains('^3.0.0'));
         expect(minIncrease.changedValue, contains('^2.0.0'));
@@ -27,9 +25,7 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes.length, greaterThanOrEqualTo(1));
-        final minIncrease = changes.firstWhere(
-          (c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease,
-        );
+        final minIncrease = changes.firstWhere((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease);
         expect(minIncrease.getMagnitude(), ApiChangeMagnitude.major);
       });
 
@@ -40,9 +36,7 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes.length, greaterThanOrEqualTo(1));
-        final minDecrease = changes.firstWhere(
-          (c) => c.operation == ApiChangeOperation.minDartSdkVersionDecrease,
-        );
+        final minDecrease = changes.firstWhere((c) => c.operation == ApiChangeOperation.minDartSdkVersionDecrease);
         expect(minDecrease.getMagnitude(), ApiChangeMagnitude.patch);
       });
 
@@ -98,14 +92,8 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes, hasLength(2));
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.maxDartSdkVersionIncrease),
-          isTrue,
-        );
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.maxDartSdkVersionIncrease), isTrue);
       });
 
       test('exact version constraint change', () {
@@ -115,14 +103,8 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes, hasLength(2));
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.maxDartSdkVersionIncrease),
-          isTrue,
-        );
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.maxDartSdkVersionIncrease), isTrue);
       });
 
       test('no change when versions are identical', () {
@@ -163,9 +145,7 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes.length, greaterThanOrEqualTo(1));
-        final minIncrease = changes.firstWhere(
-          (c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease,
-        );
+        final minIncrease = changes.firstWhere((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease);
         expect(minIncrease.getMagnitude(), ApiChangeMagnitude.major);
       });
 
@@ -176,9 +156,7 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes.length, greaterThanOrEqualTo(1));
-        final minDecrease = changes.firstWhere(
-          (c) => c.operation == ApiChangeOperation.minFlutterSdkVersionDecrease,
-        );
+        final minDecrease = changes.firstWhere((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionDecrease);
         expect(minDecrease.getMagnitude(), ApiChangeMagnitude.patch);
       });
 
@@ -233,14 +211,8 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes, hasLength(2));
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.maxFlutterSdkVersionIncrease),
-          isTrue,
-        );
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.maxFlutterSdkVersionIncrease), isTrue);
       });
 
       test('exact version constraint change', () {
@@ -250,14 +222,8 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes, hasLength(2));
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.maxFlutterSdkVersionIncrease),
-          isTrue,
-        );
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.maxFlutterSdkVersionIncrease), isTrue);
       });
 
       test('no change when versions are identical', () {
@@ -292,12 +258,8 @@ void main() {
 
     group('Android Constraint Tests', () {
       test('version increase creates major change', () {
-        final oldMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21),
-        );
-        final newMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 24),
-        );
+        final oldMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21));
+        final newMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 24));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -309,12 +271,8 @@ void main() {
       });
 
       test('version decrease creates patch change', () {
-        final oldMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 24),
-        );
-        final newMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21),
-        );
+        final oldMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 24));
+        final newMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -325,9 +283,7 @@ void main() {
 
       test('adding constraint from null creates major change', () {
         final oldMeta = PackageMetadata(androidConstraints: null);
-        final newMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21),
-        );
+        final newMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -339,9 +295,7 @@ void main() {
       });
 
       test('removing constraint to null creates patch change', () {
-        final oldMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21),
-        );
+        final oldMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21));
         final newMeta = PackageMetadata(androidConstraints: null);
 
         final changes = oldMeta.compareTo(newMeta);
@@ -354,12 +308,8 @@ void main() {
       });
 
       test('no change when versions are identical', () {
-        final oldMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21),
-        );
-        final newMeta = PackageMetadata(
-          androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21),
-        );
+        final oldMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21));
+        final newMeta = PackageMetadata(androidConstraints: AndroidPlatformConstraints(minSdkVersion: 21));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -400,12 +350,8 @@ void main() {
 
     group('iOS Constraint Tests', () {
       test('version increase creates major change', () {
-        final oldMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0),
-        );
-        final newMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 13.0),
-        );
+        final oldMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0));
+        final newMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 13.0));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -417,12 +363,8 @@ void main() {
       });
 
       test('version decrease creates patch change', () {
-        final oldMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 13.0),
-        );
-        final newMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0),
-        );
+        final oldMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 13.0));
+        final newMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -433,9 +375,7 @@ void main() {
 
       test('adding constraint from null creates major change', () {
         final oldMeta = PackageMetadata(iosConstraints: null);
-        final newMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0),
-        );
+        final newMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -447,9 +387,7 @@ void main() {
       });
 
       test('removing constraint to null creates patch change', () {
-        final oldMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0),
-        );
+        final oldMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0));
         final newMeta = PackageMetadata(iosConstraints: null);
 
         final changes = oldMeta.compareTo(newMeta);
@@ -462,12 +400,8 @@ void main() {
       });
 
       test('no change when versions are identical', () {
-        final oldMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0),
-        );
-        final newMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0),
-        );
+        final oldMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0));
+        final newMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.0));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -484,12 +418,8 @@ void main() {
       });
 
       test('decimal version changes are detected correctly', () {
-        final oldMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.1),
-        );
-        final newMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.2),
-        );
+        final oldMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.1));
+        final newMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.2));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -499,12 +429,8 @@ void main() {
       });
 
       test('decimal version decrease is detected correctly', () {
-        final oldMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.2),
-        );
-        final newMeta = PackageMetadata(
-          iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.1),
-        );
+        final oldMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.2));
+        final newMeta = PackageMetadata(iosConstraints: IOSPlatformConstraints(minimumOsVersion: 12.1));
 
         final changes = oldMeta.compareTo(newMeta);
 
@@ -532,22 +458,10 @@ void main() {
         final changes = oldMeta.compareTo(newMeta);
 
         expect(changes.length, greaterThanOrEqualTo(4));
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minAndroidSdkVersionIncrease),
-          isTrue,
-        );
-        expect(
-          changes.any((c) => c.operation == ApiChangeOperation.minIosSdkVersionIncrease),
-          isTrue,
-        );
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minDartSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minFlutterSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minAndroidSdkVersionIncrease), isTrue);
+        expect(changes.any((c) => c.operation == ApiChangeOperation.minIosSdkVersionIncrease), isTrue);
       });
     });
   });

--- a/test/fixtures/apiV100.json
+++ b/test/fixtures/apiV100.json
@@ -396,7 +396,7 @@
         "BaseClass"
       ],
       "superClassPackages": [
-        "api_guard_test"
+        "project"
       ],
       "interfaces": [
         "InterfaceA"

--- a/test/fixtures/app_v101/lib/src/api.dart
+++ b/test/fixtures/app_v101/lib/src/api.dart
@@ -16,8 +16,7 @@ class User {
 class Product {
   final String id;
   final double price;
-  final String
-  _internalId; // new private property (should be detected as added, private)
+  final String _internalId; // new private property (should be detected as added, private)
 
   Product(this.id, this.price) : _internalId = _generateInternalId();
 

--- a/test/fixtures/app_v101/lib/src/api.dart
+++ b/test/fixtures/app_v101/lib/src/api.dart
@@ -16,7 +16,8 @@ class User {
 class Product {
   final String id;
   final double price;
-  final String _internalId; // new private property (should be detected as added, private)
+  final String
+  _internalId; // new private property (should be detected as added, private)
 
   Product(this.id, this.price) : _internalId = _generateInternalId();
 

--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'helpers/test_bootstrap.dart';
+
+/// Runs before the test suite to remove stale scaffolds and bootstrap binaries/fixtures.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  _removeLegacyScaffoldDirsSync();
+  await TestBootstrap.ensureReady();
+  await testMain();
+}
+
+void _removeLegacyScaffoldDirsSync() {
+  for (final path in ['test/fixtures/package_base', 'test/fixtures/plugin_base']) {
+    final dir = Directory(path);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  }
+}

--- a/test/helpers/test_bootstrap.dart
+++ b/test/helpers/test_bootstrap.dart
@@ -1,0 +1,213 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Ensures compiled binary and Flutter scaffold fixtures exist before integration tests run.
+class TestBootstrap {
+  static const _lockRetries = 120;
+  static const _lockRetryDelay = Duration(milliseconds: 500);
+
+  static String get _rootDir => Directory.current.path;
+
+  static String get binaryPath {
+    final name = Platform.isWindows ? 'mtrust_api_guard.exe' : 'mtrust_api_guard';
+    return p.join(_rootDir, 'build', name);
+  }
+
+  static String get _lockPath => p.join(_rootDir, 'build', '.test-bootstrap.lock');
+
+  static String get _packageBaseMarker => p.join(_rootDir, '.test_scaffolds', 'package_base', 'pubspec.yaml');
+
+  static String get _pluginBaseMarker => p.join(_rootDir, '.test_scaffolds', 'plugin_base', 'pubspec.yaml');
+
+  static String get _regenerateScript => p.join(_rootDir, 'tool', 'regenerate_test_fixtures.sh');
+
+  static String? _dartSdkPath;
+
+  /// Resolved Dart SDK path for compiled binary invocations.
+  static String? get dartSdkPath {
+    _dartSdkPath ??= _resolveDartSdkPath();
+    return _dartSdkPath;
+  }
+
+  static String? _resolveDartSdkPath() {
+    final envSdk = Platform.environment['DART_SDK'];
+    if (envSdk != null && envSdk.isNotEmpty && Directory(envSdk).existsSync()) {
+      return p.normalize(envSdk);
+    }
+
+    try {
+      final result = Process.runSync(Platform.isWindows ? 'where' : 'which', ['dart'], runInShell: true);
+      if (result.exitCode != 0) {
+        return null;
+      }
+
+      final dartPath = result.stdout.toString().trim().split(RegExp(r'\r?\n')).first.trim();
+      if (dartPath.isEmpty) {
+        return null;
+      }
+
+      final binDir = p.dirname(dartPath);
+      final flutterCacheSdk = p.join(binDir, 'cache', 'dart-sdk');
+      if (Directory(flutterCacheSdk).existsSync()) {
+        return p.normalize(flutterCacheSdk);
+      }
+
+      return p.normalize(p.dirname(p.dirname(dartPath)));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Prepares compiled API Guard binary and Flutter scaffold fixtures.
+  static Future<void> ensureReady() async {
+    await _removeLegacyScaffoldDirs();
+
+    if (_isReady()) {
+      return;
+    }
+
+    await _withFileLock(_bootstrap);
+  }
+
+  static bool _isReady() {
+    return File(_packageBaseMarker).existsSync() &&
+        File(_pluginBaseMarker).existsSync() &&
+        File(binaryPath).existsSync() &&
+        !_isBinaryStale();
+  }
+
+  static Future<void> _bootstrap() async {
+    if (_isReady()) {
+      return;
+    }
+
+    await _ensureFlutterFixtures();
+    await _ensureCompiledBinary();
+  }
+
+  static Future<void> _removeLegacyScaffoldDirs() async {
+    for (final legacyDir in [
+      p.join(_rootDir, 'test', 'fixtures', 'package_base'),
+      p.join(_rootDir, 'test', 'fixtures', 'plugin_base'),
+    ]) {
+      final dir = Directory(legacyDir);
+      if (dir.existsSync()) {
+        await dir.delete(recursive: true);
+      }
+    }
+  }
+
+  static Future<void> _ensureFlutterFixtures() async {
+    final inCi = Platform.environment['CI'] == 'true';
+    final fixturesExist = File(_packageBaseMarker).existsSync() && File(_pluginBaseMarker).existsSync();
+
+    if (!inCi && fixturesExist) {
+      return;
+    }
+
+    final result = await Process.run('bash', [_regenerateScript], workingDirectory: _rootDir);
+    if (result.exitCode != 0) {
+      throw StateError(
+        'Failed to regenerate test fixtures (exit ${result.exitCode})\n'
+        'stdout: ${result.stdout}\n'
+        'stderr: ${result.stderr}',
+      );
+    }
+  }
+
+  static Future<void> _ensureCompiledBinary() async {
+    final binary = File(binaryPath);
+    if (binary.existsSync() && !_isBinaryStale()) {
+      return;
+    }
+
+    await Directory(p.dirname(binaryPath)).create(recursive: true);
+
+    final result = await Process.run(
+      'dart',
+      ['compile', 'exe', p.join(_rootDir, 'bin', 'mtrust_api_guard.dart'), '-o', binaryPath],
+      workingDirectory: _rootDir,
+    );
+
+    if (result.exitCode != 0) {
+      throw StateError(
+        'Failed to compile API Guard test binary (exit ${result.exitCode})\n'
+        'stdout: ${result.stdout}\n'
+        'stderr: ${result.stderr}',
+      );
+    }
+  }
+
+  static bool _isBinaryStale() {
+    final binary = File(binaryPath);
+    if (!binary.existsSync()) {
+      return true;
+    }
+
+    final binaryModified = binary.lastModifiedSync();
+    for (final dirName in ['lib', 'bin']) {
+      final dir = Directory(p.join(_rootDir, dirName));
+      if (!dir.existsSync()) {
+        continue;
+      }
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is File && entity.lastModifiedSync().isAfter(binaryModified)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  static Future<void> _withFileLock(Future<void> Function() action) async {
+    await Directory(p.dirname(_lockPath)).create(recursive: true);
+
+    for (var attempt = 0; attempt < _lockRetries; attempt++) {
+      if (_isReady()) {
+        return;
+      }
+
+      RandomAccessFile? lockFile;
+      try {
+        lockFile = await File(_lockPath).open(mode: FileMode.write);
+        lockFile.lockSync(FileLock.exclusive);
+        await action();
+        return;
+      } on FileSystemException {
+        await Future<void>.delayed(_lockRetryDelay);
+        if (_isReady()) {
+          return;
+        }
+      } finally {
+        try {
+          lockFile?.unlockSync();
+          await lockFile?.close();
+        } catch (_) {
+          // Another worker may hold the lock.
+        }
+      }
+    }
+
+    if (_isReady()) {
+      return;
+    }
+
+    throw StateError('Timed out waiting for test bootstrap lock');
+  }
+
+  /// Resolves the API Guard executable for integration tests.
+  static (String executable, List<String> prefixArgs) resolveApiGuardInvocation() {
+    final envBinary = Platform.environment['MTRUST_API_GUARD_BINARY'];
+    if (envBinary != null && envBinary.isNotEmpty) {
+      return (envBinary, []);
+    }
+
+    if (File(binaryPath).existsSync()) {
+      return (binaryPath, []);
+    }
+
+    return ('dart', [p.join(_rootDir, 'bin', 'mtrust_api_guard.dart')]);
+  }
+}

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 /// Recursively copy [src] directory to [dst].
 Future<void> copyDir(Directory src, Directory dst) async {
@@ -16,6 +17,23 @@ Future<void> copyDir(Directory src, Directory dst) async {
     } else if (entity is Directory) {
       await Directory(newPath).create(recursive: true);
     }
+  }
+}
+
+/// Copies the pre-generated package scaffold into [target].
+Future<void> copyPackageBase(Directory target, {String? packageName}) async {
+  final packageBase = Directory(p.join('.test_scaffolds', 'package_base'));
+  if (!packageBase.existsSync()) {
+    throw StateError('Package base fixture missing at ${packageBase.path}. Run flutter test to bootstrap.');
+  }
+
+  await copyDir(packageBase, target);
+
+  if (packageName != null) {
+    final pubspecFile = File(p.join(target.path, 'pubspec.yaml'));
+    final editor = YamlEditor(await pubspecFile.readAsString());
+    editor.update(['name'], packageName);
+    await pubspecFile.writeAsString(editor.toString());
   }
 }
 
@@ -78,6 +96,8 @@ class TestFixtures {
   final Directory appV101Dir;
   final Directory appV110Dir;
   final Directory appV200Dir;
+  final Directory packageBaseDir;
+  final Directory pluginBaseDir;
   final File expectedChangelogFile;
 
   TestFixtures()
@@ -86,5 +106,7 @@ class TestFixtures {
       appV101Dir = Directory('test/fixtures/app_v101'),
       appV110Dir = Directory('test/fixtures/app_v110'),
       appV200Dir = Directory('test/fixtures/app_v200'),
+      packageBaseDir = Directory('.test_scaffolds/package_base'),
+      pluginBaseDir = Directory('.test_scaffolds/plugin_base'),
       expectedChangelogFile = File('test/fixtures/expected_changelog.md');
 }

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -20,8 +20,7 @@ Future<void> copyDir(Directory src, Directory dst) async {
 }
 
 /// Run a process and optionally capture stdout.
-Future<String> runProcess(String cmd, List<String> args,
-    {String? workingDir, bool captureOutput = false}) async {
+Future<String> runProcess(String cmd, List<String> args, {String? workingDir, bool captureOutput = false}) async {
   printOnFailure('Running: $cmd ${args.join(' ')} in $workingDir');
   final result = await Process.run(cmd, args, workingDirectory: workingDir);
 
@@ -44,13 +43,9 @@ Future<String> runProcess(String cmd, List<String> args,
 
 /// Strip changelog content for comparison by removing dynamic content like commit hashes and dates.
 String stripChangelog(String changelog) {
-  final commitLinkRegexp =
-      RegExp(r'\(\[([a-z0-9]{7})\]\(commit/[a-z0-9]{7}\)\)');
-  final releasedOnLineRegexp = RegExp(
-      r'Released on: \d{1,2}/\d{1,2}/\d{4}, changelog automatically generated.');
-  return changelog
-      .replaceAll(commitLinkRegexp, '')
-      .replaceAll(releasedOnLineRegexp, '');
+  final commitLinkRegexp = RegExp(r'\(\[([a-z0-9]{7})\]\(commit/[a-z0-9]{7}\)\)');
+  final releasedOnLineRegexp = RegExp(r'Released on: \d{1,2}/\d{1,2}/\d{4}, changelog automatically generated.');
+  return changelog.replaceAll(commitLinkRegexp, '').replaceAll(releasedOnLineRegexp, '');
 }
 
 /// Remove sdkVersion from JSON metadata to ignore SDK version differences in tests.
@@ -86,10 +81,10 @@ class TestFixtures {
   final File expectedChangelogFile;
 
   TestFixtures()
-      : fixturesDir = Directory('test/fixtures'),
-        appV100Dir = Directory('test/fixtures/app_v100'),
-        appV101Dir = Directory('test/fixtures/app_v101'),
-        appV110Dir = Directory('test/fixtures/app_v110'),
-        appV200Dir = Directory('test/fixtures/app_v200'),
-        expectedChangelogFile = File('test/fixtures/expected_changelog.md');
+    : fixturesDir = Directory('test/fixtures'),
+      appV100Dir = Directory('test/fixtures/app_v100'),
+      appV101Dir = Directory('test/fixtures/app_v101'),
+      appV110Dir = Directory('test/fixtures/app_v110'),
+      appV200Dir = Directory('test/fixtures/app_v200'),
+      expectedChangelogFile = File('test/fixtures/expected_changelog.md');
 }

--- a/test/helpers/test_setup.dart
+++ b/test/helpers/test_setup.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
+import 'test_bootstrap.dart';
 import 'test_helpers.dart';
 
 /// Helper class for managing test setup and teardown.
@@ -17,6 +18,8 @@ class TestSetup {
 
   /// Set up the test environment with a temporary directory.
   Future<void> setUp() async {
+    await TestBootstrap.ensureReady();
+
     tempDir = await Directory.systemTemp.createTemp('api_guard_test_');
     tempDir = Directory(p.join(tempDir.path, 'api_guard_test'));
     if (tempDir.existsSync()) {
@@ -27,8 +30,6 @@ class TestSetup {
     // Create a unique cache directory for this test
     cacheDir = Directory(p.join(tempDir.path, 'cache'));
     await cacheDir.create(recursive: true);
-
-    await runApiGuard('cache', ['--clear']); // Clear cache before each test
   }
 
   /// Clean up the test environment.
@@ -76,16 +77,24 @@ class TestSetup {
 
   /// Run the API Guard command and handle output.
   Future<void> runApiGuard(String command, List<String> args) async {
+    final (executable, prefixArgs) = TestBootstrap.resolveApiGuardInvocation();
+    final invocationArgs = [...prefixArgs, command, ...args];
+
     printOnFailure('Running API Guard: $command ${args.join(' ')} on ${tempDir.path}');
-    printOnFailure("dart ${rootDir.path}/bin/mtrust_api_guard.dart $command ${args.join(' ')}");
+    printOnFailure('$executable ${invocationArgs.join(' ')}');
 
     // Set the cache directory environment variable for this test
     final environment = Map<String, String>.from(Platform.environment);
     environment['MTRUST_API_GUARD_CACHE_DIR'] = cacheDir.path;
 
+    final sdkPath = TestBootstrap.dartSdkPath;
+    if (sdkPath != null) {
+      environment['DART_SDK'] = sdkPath;
+    }
+
     final result = await Process.run(
-      'dart',
-      ["${rootDir.path}/bin/mtrust_api_guard.dart", command, ...args],
+      executable,
+      invocationArgs,
       workingDirectory: tempDir.path,
       environment: environment,
     );
@@ -122,42 +131,13 @@ class TestSetup {
     }
   }
 
-  Future<void> _clearDir(String dirName) async {
-    final dir = Directory(p.join(tempDir.path, dirName));
-    if (dir.existsSync()) {
-      await dir.delete(recursive: true);
-      await dir.create();
-    }
-  }
-
   /// Set up a Flutter package in the test directory.
   Future<void> setupFlutterPackage() async {
-    await runProcess('flutter', [
-      'create',
-      '.',
-      '--template',
-      'package',
-      '--project-name',
-      'api_guard_test',
-    ], workingDir: tempDir.path);
-
-    // remove the contents of lib/ and test/ directories
-    await _clearDir('lib');
-    await _clearDir('test');
+    await copyDir(fixtures.packageBaseDir, tempDir);
   }
 
   /// Set up a Flutter plugin in the test directory.
   Future<void> setupFlutterPlugin() async {
-    await runProcess('flutter', [
-      'create',
-      '.',
-      '--template',
-      'plugin',
-      '--project-name',
-      'api_guard_test',
-    ], workingDir: tempDir.path);
-    // remove the contents of lib/ and test/ directories
-    await _clearDir('lib');
-    await _clearDir('test');
+    await copyDir(fixtures.pluginBaseDir, tempDir);
   }
 }

--- a/test/helpers/test_setup.dart
+++ b/test/helpers/test_setup.dart
@@ -23,11 +23,11 @@ class TestSetup {
       await tempDir.delete(recursive: true); // Ensure a clean state
     }
     await tempDir.create();
-    
+
     // Create a unique cache directory for this test
     cacheDir = Directory(p.join(tempDir.path, 'cache'));
     await cacheDir.create(recursive: true);
-    
+
     await runApiGuard('cache', ['--clear']); // Clear cache before each test
   }
 
@@ -42,32 +42,22 @@ class TestSetup {
     try {
       await runProcess('git', ['remote', 'get-url', 'origin'], workingDir: tempDir.path);
     } catch (_) {
-      await runProcess(
-        'git',
-        ['remote', 'add', 'origin', 'https://github.com/emdgroup/mtrust-api-guard.git'],
-        workingDir: tempDir.path,
-      );
+      await runProcess('git', [
+        'remote',
+        'add',
+        'origin',
+        'https://github.com/emdgroup/mtrust-api-guard.git',
+      ], workingDir: tempDir.path);
     }
-    await runProcess(
-      'git',
-      ['config', 'user.email', TestConstants.testEmail],
-      workingDir: tempDir.path,
-    );
-    await runProcess(
-      'git',
-      ['config', 'user.name', TestConstants.testUser],
-      workingDir: tempDir.path,
-    );
+    await runProcess('git', ['config', 'user.email', TestConstants.testEmail], workingDir: tempDir.path);
+    await runProcess('git', ['config', 'user.name', TestConstants.testUser], workingDir: tempDir.path);
   }
 
   /// Set version in pubspec.yaml.
   void setVersion(String version) {
     final yaml = File(p.join(tempDir.path, 'pubspec.yaml'));
     yaml.writeAsStringSync(
-      yaml.readAsStringSync().replaceFirst(
-            RegExp(r'version: \d+\.\d+\.\d+'),
-            'version: $version',
-          ),
+      yaml.readAsStringSync().replaceFirst(RegExp(r'version: \d+\.\d+\.\d+'), 'version: $version'),
     );
   }
 
@@ -142,11 +132,14 @@ class TestSetup {
 
   /// Set up a Flutter package in the test directory.
   Future<void> setupFlutterPackage() async {
-    await runProcess(
-      'flutter',
-      ['create', '.', '--template', 'package', '--project-name', 'api_guard_test'],
-      workingDir: tempDir.path,
-    );
+    await runProcess('flutter', [
+      'create',
+      '.',
+      '--template',
+      'package',
+      '--project-name',
+      'api_guard_test',
+    ], workingDir: tempDir.path);
 
     // remove the contents of lib/ and test/ directories
     await _clearDir('lib');
@@ -155,11 +148,14 @@ class TestSetup {
 
   /// Set up a Flutter plugin in the test directory.
   Future<void> setupFlutterPlugin() async {
-    await runProcess(
-      'flutter',
-      ['create', '.', '--template', 'plugin', '--project-name', 'api_guard_test'],
-      workingDir: tempDir.path,
-    );
+    await runProcess('flutter', [
+      'create',
+      '.',
+      '--template',
+      'plugin',
+      '--project-name',
+      'api_guard_test',
+    ], workingDir: tempDir.path);
     // remove the contents of lib/ and test/ directories
     await _clearDir('lib');
     await _clearDir('test');

--- a/test/version/calculate_next_version_test.dart
+++ b/test/version/calculate_next_version_test.dart
@@ -34,11 +34,12 @@ void main() {
     });
 
     Future<void> createTag(String tag) async {
-      final commitResult = await Process.run(
-        'git',
-        ['commit', '--allow-empty', '-m', tag],
-        workingDirectory: tempDir.path,
-      );
+      final commitResult = await Process.run('git', [
+        'commit',
+        '--allow-empty',
+        '-m',
+        tag,
+      ], workingDirectory: tempDir.path);
       expect(commitResult.exitCode, 0, reason: commitResult.stderr.toString());
       final tagResult = await Process.run('git', ['tag', tag], workingDirectory: tempDir.path);
       expect(tagResult.exitCode, 0, reason: tagResult.stderr.toString());
@@ -62,14 +63,7 @@ void main() {
     });
 
     test('starts pre-release for first pre-release bump', () async {
-      final next = await calculateNextVersion(
-        Version.parse('0.0.1'),
-        ApiChangeMagnitude.minor,
-        true,
-        tempDir,
-        'v',
-        '',
-      );
+      final next = await calculateNextVersion(Version.parse('0.0.1'), ApiChangeMagnitude.minor, true, tempDir, 'v', '');
 
       expect(next, '0.1.0-1');
     });
@@ -116,14 +110,7 @@ void main() {
     test('skips existing tags when choosing next pre-release', () async {
       await createTag('v0.1.0-1');
 
-      final next = await calculateNextVersion(
-        Version.parse('0.0.1'),
-        ApiChangeMagnitude.minor,
-        true,
-        tempDir,
-        'v',
-        '',
-      );
+      final next = await calculateNextVersion(Version.parse('0.0.1'), ApiChangeMagnitude.minor, true, tempDir, 'v', '');
 
       expect(next, '0.1.0-2');
     });

--- a/tool/cleanup_legacy_scaffolds.dart
+++ b/tool/cleanup_legacy_scaffolds.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+/// Removes legacy Flutter scaffolds from test/fixtures before test discovery.
+void main() {
+  for (final path in ['test/fixtures/package_base', 'test/fixtures/plugin_base']) {
+    final dir = Directory(path);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+      stdout.writeln('Removed legacy scaffold: $path');
+    }
+  }
+}

--- a/tool/regenerate_test_fixtures.sh
+++ b/tool/regenerate_test_fixtures.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PACKAGE_BASE="$ROOT/.test_scaffolds/package_base"
+PLUGIN_BASE="$ROOT/.test_scaffolds/plugin_base"
+
+clear_dir_contents() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    find "$dir" -mindepth 1 -delete
+  fi
+}
+
+create_package_base() {
+  rm -rf "$PACKAGE_BASE"
+  mkdir -p "$PACKAGE_BASE"
+  (
+    cd "$PACKAGE_BASE"
+    flutter create . --template package --project-name api_guard_test
+    clear_dir_contents lib
+    rm -rf test .dart_tool
+    mkdir -p lib
+  )
+}
+
+create_plugin_base() {
+  rm -rf "$PLUGIN_BASE"
+  mkdir -p "$PLUGIN_BASE"
+  (
+    cd "$PLUGIN_BASE"
+    flutter create . --template plugin --project-name api_guard_test
+    clear_dir_contents lib
+    rm -rf test example .dart_tool
+    mkdir -p lib
+  )
+}
+
+create_package_base
+create_plugin_base
+
+# Remove legacy scaffold locations that flutter test would discover as tests.
+rm -rf "$ROOT/test/fixtures/package_base" "$ROOT/test/fixtures/plugin_base"


### PR DESCRIPTION
## Summary
- Upgrade `analyzer` from 7.x to ^13.3.0 (latest resolvable; 14 blocked by `json_serializable`)
- Raise minimum Dart SDK to `>=3.11.0`
- Migrate `doc_visitor.dart` and `doc_generator.dart` from deprecated Element2 APIs to stabilized element model
- Upgrade build ecosystem (`build` ^4, `build_runner` ^2.15, `json_serializable` ^6.14)
- Remove unused direct dependencies (`code_builder`, `dart_style`)

## Test plan
- [x] `dart analyze` — no errors
- [x] `dart test` — 83/83 passed
- [x] `dart run build_runner build` — regenerated `*.g.dart` files