### PR TITLE
fix(changelog): group pubspec changes and fix dependency text

### DIFF
--- a/lib/doc_comparator/api_change.dart
+++ b/lib/doc_comparator/api_change.dart
@@ -75,7 +75,7 @@ enum ApiChangeOperation {
   // Pubspec-specific changes
   dependencyVersionChange(ApiChangeMagnitude.patch),
   dependencyAddition(ApiChangeMagnitude.patch),
-  dependencyRemoval(ApiChangeMagnitude.minor),
+  dependencyRemoval(ApiChangeMagnitude.patch),
   // Dart SDK constraints
   minDartSdkVersionDecrease(ApiChangeMagnitude.patch),
   minDartSdkVersionIncrease(ApiChangeMagnitude.major),

--- a/lib/doc_comparator/api_change_formatter.dart
+++ b/lib/doc_comparator/api_change_formatter.dart
@@ -40,6 +40,7 @@ class ApiChangeFormatter {
       for (final component in sortedComponents) {
         final firstChange = componentChanges[component]!.first;
         final componentObj = firstChange.component;
+        final isMetaGroup = componentObj.type == DocComponentType.metaType;
         final typeLabel = componentObj.type.name.replaceAll("Type", "").toLowerCase();
         final filePath = componentObj.filePath;
 
@@ -47,9 +48,11 @@ class ApiChangeFormatter {
             ? fileUrlBuilder!(filePath) ?? filePath
             : filePath;
 
+        final displayName = isMetaGroup ? (filePath ?? 'pubspec.yaml') : componentObj.genericName;
+
         changelogBuffer.writeln();
         changelogBuffer.writeln(
-          '**`${typeLabel.toLowerCase()}` ${componentObj.genericName}** '
+          '**`${typeLabel.toLowerCase()}` $displayName** '
           '${filePath != null ? '([$filePath]($linkTarget))' : ''}',
         );
 
@@ -73,7 +76,12 @@ class ApiChangeFormatter {
 
   // Group changes by component
   Map<String, List<ApiChange>> _groupByComponent(List<ApiChange> changes) {
-    return groupBy(changes, (change) => change.component.name);
+    return groupBy(changes, (change) {
+      if (change.component.type == DocComponentType.metaType) {
+        return '__meta__${change.component.filePath ?? 'pubspec.yaml'}';
+      }
+      return change.component.name;
+    });
   }
 
   // Group changes by generating a change category that considers the type,
@@ -85,7 +93,12 @@ class ApiChangeFormatter {
       // and, for parameter changes, the parent (constructor/method) name
       (change) {
         var key = '${change.runtimeType}-${change.operation}';
-        if (change is ConstructorParameterApiChange) {
+        if (change is MetaApiChange &&
+            (change.operation == ApiChangeOperation.dependencyRemoval ||
+                change.operation == ApiChangeOperation.dependencyAddition ||
+                change.operation == ApiChangeOperation.dependencyVersionChange)) {
+          key += '-${change.component.name}';
+        } else if (change is ConstructorParameterApiChange) {
           key += '-${change.constructor.name}';
         } else if (change is MethodParameterApiChange) {
           key += '-${change.method.name}';
@@ -238,13 +251,13 @@ extension ApiChangeFormattingHelpers on List<ApiChange> {
         return '➖ Mixin removed: ${_formatChangedValues()}';
 
       case ApiChangeOperation.dependencyAddition:
-        return '📦 Dependency added: ${change.changedValue}';
+        return '📦 Added `${_dependencyName(change)}`: ${change.changedValue}';
 
       case ApiChangeOperation.dependencyRemoval:
-        return '📦 Dependency removed: ${change.changedValue}';
+        return '📦 Removed `${_dependencyName(change)}`';
 
       case ApiChangeOperation.dependencyVersionChange:
-        return '📦 Dependency version changed: ${change.changedValue}';
+        return '📦 `${_dependencyName(change)}` version changed: ${change.changedValue}';
 
       case ApiChangeOperation.minDartSdkVersionDecrease:
         return '🎯 Minimum Dart SDK version decreased: ${change.changedValue}';
@@ -296,6 +309,15 @@ extension ApiChangeFormattingHelpers on List<ApiChange> {
 
   String _formatChangedValues() {
     return map((change) => change.changedValue).join(', ');
+  }
+
+  String _dependencyName(ApiChange change) {
+    final name = change.component.name;
+    const prefix = 'dependency `';
+    if (name.startsWith(prefix) && name.endsWith('`')) {
+      return name.substring(prefix.length, name.length - 1);
+    }
+    return name;
   }
 
   String _formatAnnotations() {

--- a/test/commands/version_command_test.dart
+++ b/test/commands/version_command_test.dart
@@ -211,12 +211,12 @@ void main() {
       await testSetup.commitChanges('chore: remove path dependency');
       await testSetup.runApiGuard('version', ["--verbose"]);
 
-      // Removing a dependency might trigger a minor or patch change
-      expect(testSetup.getCurrentVersion(), TestConstants.minorVersion);
+      // Removing an unused dependency is a patch-level pubspec change
+      expect(testSetup.getCurrentVersion(), '0.0.3');
 
       // Verify tag was created
       final tags = await runProcess('git', ['tag'], workingDir: testSetup.tempDir.path, captureOutput: true);
-      expect(tags, contains('v${TestConstants.minorVersion}'));
+      expect(tags, contains('v0.0.3'));
     });
 
     test('detects patch version change when changing SDK constraints', () async {

--- a/test/comparators/api_change_formatter_test.dart
+++ b/test/comparators/api_change_formatter_test.dart
@@ -1,0 +1,39 @@
+import 'package:mtrust_api_guard/doc_comparator/api_change_formatter.dart';
+import 'package:mtrust_api_guard/mtrust_api_guard.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ApiChangeFormatter', () {
+    test('groups pubspec meta changes under a single header', () {
+      final changes = [
+        MetaApiChange.dependencyRemoved(dependencyName: 'build_config'),
+        MetaApiChange.dependencyRemoved(dependencyName: 'build'),
+        MetaApiChange.dependencyVersionChange(
+          dependencyName: 'analyzer',
+          version: '^13.3.0',
+          previousVersion: '^7.4.5',
+        ),
+        MetaApiChange.minDartSdkVersionIncrease(
+          version: '>=3.11.0 <4.0.0',
+          previousVersion: '>=3.0.0 <4.0.0',
+        ),
+      ];
+
+      final formatted = ApiChangeFormatter(changes, markdownHeaderLevel: 4).format();
+
+      expect(formatted, contains('**`meta` pubspec.yaml**'));
+      expect(formatted, isNot(contains('dependency `build_config`')));
+      expect(formatted, contains('📦 Removed `build_config`'));
+      expect(formatted, contains('📦 Removed `build`'));
+      expect(formatted, contains('📦 `analyzer` version changed: from `^7.4.5` to `^13.3.0`'));
+      expect(formatted, isNot(contains('removed: removed')));
+      expect('**`meta` pubspec.yaml**'.allMatches(formatted).length, 2);
+    });
+
+    test('dependency removal is formatted as patch change', () {
+      final change = MetaApiChange.dependencyRemoved(dependencyName: 'code_builder');
+
+      expect(change.getMagnitude(), ApiChangeMagnitude.patch);
+    });
+  });
+}

--- a/test/comparators/metadata_comparator_test.dart
+++ b/test/comparators/metadata_comparator_test.dart
@@ -440,6 +440,49 @@ void main() {
       });
     });
 
+    group('Dependency Tests', () {
+      test('dependency removal creates patch change', () {
+        final oldMeta = PackageMetadata(
+          dependencies: [PackageDependency(packageName: 'path', packageVersion: '^1.8.0')],
+        );
+        final newMeta = PackageMetadata(dependencies: []);
+
+        final changes = oldMeta.compareTo(newMeta);
+
+        expect(changes, hasLength(1));
+        expect(changes.first.operation, ApiChangeOperation.dependencyRemoval);
+        expect(changes.first.getMagnitude(), ApiChangeMagnitude.patch);
+      });
+
+      test('dependency addition creates patch change', () {
+        final oldMeta = PackageMetadata(dependencies: []);
+        final newMeta = PackageMetadata(
+          dependencies: [PackageDependency(packageName: 'path', packageVersion: '^1.8.0')],
+        );
+
+        final changes = oldMeta.compareTo(newMeta);
+
+        expect(changes, hasLength(1));
+        expect(changes.first.operation, ApiChangeOperation.dependencyAddition);
+        expect(changes.first.getMagnitude(), ApiChangeMagnitude.patch);
+      });
+
+      test('dependency version change creates patch change', () {
+        final oldMeta = PackageMetadata(
+          dependencies: [PackageDependency(packageName: 'path', packageVersion: '^1.8.0')],
+        );
+        final newMeta = PackageMetadata(
+          dependencies: [PackageDependency(packageName: 'path', packageVersion: '^1.9.0')],
+        );
+
+        final changes = oldMeta.compareTo(newMeta);
+
+        expect(changes, hasLength(1));
+        expect(changes.first.operation, ApiChangeOperation.dependencyVersionChange);
+        expect(changes.first.getMagnitude(), ApiChangeMagnitude.patch);
+      });
+    });
+
     group('Combined Constraint Tests', () {
       test('multiple constraint changes are detected together', () {
         final oldMeta = PackageMetadata(


### PR DESCRIPTION
## Summary
- Fix redundant "Dependency removed: removed" wording by using the package name in bullets
- Group all pubspec/meta changes under a single `pubspec.yaml` header per magnitude section
- Reclassify dependency removal as patch (consistent with addition and version bumps)

## Test plan
- [x] `dart test test/comparators/api_change_formatter_test.dart`
- [x] `dart test test/comparators/metadata_comparator_test.dart`
- [x] `dart test test/commands/version_command_test.dart --name dependency`