### PR TITLE
fix(version): keep stable base for all magnitudes when bumping from pre-release

### DIFF
--- a/lib/version/calculate_next_version.dart
+++ b/lib/version/calculate_next_version.dart
@@ -9,7 +9,7 @@ Version stableVersion(Version version) => Version(version.major, version.minor, 
 
 Version targetStableForPreRelease(Version original, ApiChangeMagnitude magnitude) {
   final stable = stableVersion(original);
-  if (original.isPreRelease && magnitude == ApiChangeMagnitude.patch) {
+  if (original.isPreRelease) {
     return stable;
   }
   return bumpStable(stable, magnitude);

--- a/test/commands/version_command_test.dart
+++ b/test/commands/version_command_test.dart
@@ -286,16 +286,18 @@ void main() {
       expect(testSetup.getCurrentVersion(), '0.1.0-1');
 
       // 3. Apply major changes and create another pre-release
+      // Since 0.1.0 has not been released yet, major changes still accumulate
+      // under the same stable target — the pre-release counter increments.
       await copyDir(testSetup.fixtures.appV200Dir, testSetup.tempDir);
       await testSetup.commitChanges('feat: implement compatibility with v${TestConstants.majorVersion}');
 
       await testSetup.runApiGuard('version', ['--pre-release']);
-      expect(testSetup.getCurrentVersion(), '1.0.0-1');
+      expect(testSetup.getCurrentVersion(), '0.1.0-2');
 
       // 4. Finalize the release (removes pre-release suffix)
       await testSetup.runApiGuard('version', []);
 
-      expect(testSetup.getCurrentVersion(), '1.0.0');
+      expect(testSetup.getCurrentVersion(), '0.1.0');
     });
 
     test('pre-release prefix option applies custom suffix including incrementing numbers', () async {

--- a/test/version/calculate_next_version_test.dart
+++ b/test/version/calculate_next_version_test.dart
@@ -81,7 +81,7 @@ void main() {
       expect(next, '0.1.0-dev.1');
     });
 
-    test('bumps stable base and restarts pre-release suffix', () async {
+    test('keeps stable base when pre-release has minor change', () async {
       final next = await calculateNextVersion(
         Version.parse('0.1.0-dev.3'),
         ApiChangeMagnitude.minor,
@@ -91,7 +91,24 @@ void main() {
         'dev',
       );
 
-      expect(next, '0.2.0-dev.1');
+      expect(next, '0.1.0-dev.4');
+    });
+
+    test('keeps stable base when pre-release has major change', () async {
+      await createTag('liquid_flutter/v23.0.0-1');
+      await createTag('liquid_flutter/v23.0.0-2');
+      await createTag('liquid_flutter/v23.0.0-3');
+
+      final next = await calculateNextVersion(
+        Version.parse('23.0.0-3'),
+        ApiChangeMagnitude.major,
+        true,
+        tempDir,
+        'liquid_flutter/v',
+        '',
+      );
+
+      expect(next, '23.0.0-4');
     });
 
     test('increments dev pre-release on same stable base', () async {


### PR DESCRIPTION
## Problem

When the base version is already a pre-release (e.g. `23.0.0-3`), the bumper was incorrectly escalating the stable base for minor and major API changes.

For example: `23.0.0-3` + breaking (major) change → `24.0.0-1` instead of `23.0.0-4`.

This was observed in [liquid-flutter CI run #28321633162](https://github.com/emdgroup-liquid/liquid-flutter/actions/runs/28321633162/job/83905714199).

## Root cause

In `targetStableForPreRelease`, only `patch` magnitude was exempted from bumping the stable base. Minor and major magnitudes would still bump it, even though `23.0.0` had never actually been shipped.

A prior fix (#28) addressed the patch case but left minor/major broken.

## Fix

If the base version is already a pre-release, the stable target is always preserved — regardless of change magnitude. The unreleased stable base absorbs all changes; only the pre-release counter increments.

```
// Before
if (original.isPreRelease && magnitude == ApiChangeMagnitude.patch) {
  return stable;
}
return bumpStable(stable, magnitude); // fired for minor/major

// After
if (original.isPreRelease) {
  return stable; // always keep stable base if not yet released
}
return bumpStable(stable, magnitude);
```

## Tests

- Updated the existing `'bumps stable base and restarts pre-release suffix'` test (now correctly expects `0.1.0-dev.4` for minor change from `0.1.0-dev.3`)
- Added new test covering the exact real-world scenario: `23.0.0-3` + major → `23.0.0-4`