### PR TITLE
fix(workspace): topological sort and incremental dep propagation

### DIFF
--- a/lib/version/workspace_utils.dart
+++ b/lib/version/workspace_utils.dart
@@ -133,7 +133,7 @@ List<WorkspacePackage> sortPackagesTopologically(List<WorkspacePackage> packages
   // Kahn's algorithm for topological sort
   final inDegree = <String, int>{for (final p in packages) p.name: 0};
   for (final entry in deps.entries) {
-    for (final dep in entry.value) {
+    for (final _ in entry.value) {
       inDegree[entry.key] = (inDegree[entry.key] ?? 0) + 1;
     }
   }

--- a/lib/version/workspace_utils.dart
+++ b/lib/version/workspace_utils.dart
@@ -95,6 +95,83 @@ List<WorkspacePackage> getWorkspacePackages(WorkspaceInfo workspace) {
   return packages;
 }
 
+/// Returns the workspace packages sorted in topological order so that a package
+/// always appears before any other package that depends on it.
+/// Packages with no intra-workspace dependencies come first.
+List<WorkspacePackage> sortPackagesTopologically(List<WorkspacePackage> packages) {
+  // Build a name -> package map and a dependency graph
+  final packageNames = {for (final p in packages) p.name};
+  final deps = <String, Set<String>>{};
+
+  for (final package in packages) {
+    final pubspecFile = File(path.join(package.directory.path, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) {
+      deps[package.name] = {};
+      continue;
+    }
+    try {
+      final content = pubspecFile.readAsStringSync();
+      final pubspec = loadYaml(content) as Map;
+      final workspaceDeps = <String>{};
+      for (final section in ['dependencies', 'dev_dependencies']) {
+        final sectionMap = pubspec[section];
+        if (sectionMap is Map) {
+          for (final dep in sectionMap.keys) {
+            if (packageNames.contains(dep as String)) {
+              workspaceDeps.add(dep);
+            }
+          }
+        }
+      }
+      deps[package.name] = workspaceDeps;
+    } catch (e) {
+      logger.warn('Error reading dependencies for ${package.name}: $e');
+      deps[package.name] = {};
+    }
+  }
+
+  // Kahn's algorithm for topological sort
+  final inDegree = <String, int>{for (final p in packages) p.name: 0};
+  for (final entry in deps.entries) {
+    for (final dep in entry.value) {
+      inDegree[entry.key] = (inDegree[entry.key] ?? 0) + 1;
+    }
+  }
+
+  // Build reverse map: dependency -> list of packages that depend on it
+  final dependents = <String, List<String>>{};
+  for (final entry in deps.entries) {
+    for (final dep in entry.value) {
+      dependents.putIfAbsent(dep, () => []).add(entry.key);
+    }
+  }
+
+  final queue = <String>[
+    for (final p in packages)
+      if ((inDegree[p.name] ?? 0) == 0) p.name,
+  ];
+  final sorted = <String>[];
+
+  while (queue.isNotEmpty) {
+    final current = queue.removeAt(0);
+    sorted.add(current);
+    for (final dependent in (dependents[current] ?? [])) {
+      inDegree[dependent] = (inDegree[dependent] ?? 1) - 1;
+      if (inDegree[dependent] == 0) {
+        queue.add(dependent);
+      }
+    }
+  }
+
+  if (sorted.length != packages.length) {
+    logger.warn('Cycle detected in workspace dependency graph; falling back to original order');
+    return packages;
+  }
+
+  final packageMap = {for (final p in packages) p.name: p};
+  return sorted.map((name) => packageMap[name]!).toList();
+}
+
 /// Checks if a package directory has changes between two git refs
 Future<bool> packageHasChanges(String packagePath, String baseRef, String newRef, Directory gitRoot) async {
   try {

--- a/lib/version/workspace_version.dart
+++ b/lib/version/workspace_version.dart
@@ -39,12 +39,21 @@ Future<WorkspaceVersionResult> versionWorkspace({
 
   logger.info('Found ${packages.length} packages in workspace');
 
+  // Sort packages so dependencies are versioned before their consumers.
+  // This ensures that when a consumer is versioned, its pubspec already
+  // reflects the updated sibling constraint, making the dep bump part of
+  // the same versioned commit and preventing cascade bumps on the next run.
+  final sortedPackages = sortPackagesTopologically(packages);
+
   // Track which packages were versioned and their new versions
   final packageResults = <String, VersionResult>{};
   final packageVersions = <String, Version>{};
 
-  // Step 1: Version each changed package
-  for (final package in packages) {
+  // Version each changed package in topological order.
+  // After each versioned package, immediately update its consumers' pubspecs
+  // so that subsequent packages in the loop see the new constraint when they
+  // are checked for changes and versioned.
+  for (final package in sortedPackages) {
     logger.info('Processing package: ${package.name}');
 
     // Determine the base ref for this package
@@ -88,17 +97,19 @@ Future<WorkspaceVersionResult> versionWorkspace({
       packageResults[package.name] = result;
       packageVersions[package.name] = result.version;
       logger.success('Versioned ${package.name} to ${result.version}');
+
+      // Immediately propagate this package's new version into the pubspecs of
+      // any workspace packages that depend on it, so they see the updated
+      // constraint when they are versioned later in this same loop.
+      await updateWorkspaceDependencies(
+        workspace: workspace,
+        packages: sortedPackages,
+        updatedVersions: {package.name: result.version},
+      );
     } catch (e) {
       logger.err('Failed to version package ${package.name}: $e');
       rethrow;
     }
-  }
-
-  // Step 2: Update dependencies between workspace packages
-  if (packageVersions.isNotEmpty) {
-    logger.info('Updating workspace dependencies...');
-    await updateWorkspaceDependencies(workspace: workspace, packages: packages, updatedVersions: packageVersions);
-    logger.success('Updated workspace dependencies');
   }
 
   return WorkspaceVersionResult(packageResults: packageResults, packageVersions: packageVersions);

--- a/test/version/workspace_utils_test.dart
+++ b/test/version/workspace_utils_test.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:mtrust_api_guard/version/workspace_utils.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+/// Creates a minimal temporary workspace package directory with a pubspec.yaml.
+WorkspacePackage _makePackage(
+  Directory tempDir,
+  String name, {
+  List<String> workspaceDeps = const [],
+}) {
+  final dir = Directory(path.join(tempDir.path, name))..createSync();
+  final pubspec = StringBuffer()
+    ..writeln('name: $name')
+    ..writeln('version: 0.1.0')
+    ..writeln('environment:')
+    ..writeln('  sdk: ">=3.0.0 <4.0.0"');
+  if (workspaceDeps.isNotEmpty) {
+    pubspec.writeln('dependencies:');
+    for (final dep in workspaceDeps) {
+      pubspec.writeln('  $dep: ^0.1.0');
+    }
+  }
+  File(path.join(dir.path, 'pubspec.yaml')).writeAsStringSync(pubspec.toString());
+  return WorkspacePackage(
+    name: name,
+    directory: dir,
+    relativePath: name,
+  );
+}
+
+void main() {
+  group('sortPackagesTopologically', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('workspace_sort_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('packages with no dependencies keep stable order', () {
+      final a = _makePackage(tempDir, 'pkg_a');
+      final b = _makePackage(tempDir, 'pkg_b');
+      final c = _makePackage(tempDir, 'pkg_c');
+
+      final sorted = sortPackagesTopologically([a, b, c]);
+
+      expect(sorted.map((p) => p.name).toList(), equals(['pkg_a', 'pkg_b', 'pkg_c']));
+    });
+
+    test('dependency comes before dependent', () {
+      // pkg_child depends on pkg_root
+      final root = _makePackage(tempDir, 'pkg_root');
+      final child = _makePackage(tempDir, 'pkg_child', workspaceDeps: ['pkg_root']);
+
+      final sorted = sortPackagesTopologically([child, root]);
+
+      expect(sorted.map((p) => p.name).toList(), equals(['pkg_root', 'pkg_child']));
+    });
+
+    test('diamond dependency: root before both mid packages before leaf', () {
+      // leaf depends on mid_a and mid_b; both depend on root
+      final root = _makePackage(tempDir, 'root');
+      final midA = _makePackage(tempDir, 'mid_a', workspaceDeps: ['root']);
+      final midB = _makePackage(tempDir, 'mid_b', workspaceDeps: ['root']);
+      final leaf = _makePackage(tempDir, 'leaf', workspaceDeps: ['mid_a', 'mid_b']);
+
+      final sorted = sortPackagesTopologically([leaf, midB, midA, root]);
+      final names = sorted.map((p) => p.name).toList();
+
+      expect(names.indexOf('root'), lessThan(names.indexOf('mid_a')));
+      expect(names.indexOf('root'), lessThan(names.indexOf('mid_b')));
+      expect(names.indexOf('mid_a'), lessThan(names.indexOf('leaf')));
+      expect(names.indexOf('mid_b'), lessThan(names.indexOf('leaf')));
+    });
+
+    test('liquid_flutter scenario: liquid_flutter before test_utils and reactive_forms', () {
+      final core = _makePackage(tempDir, 'liquid_flutter');
+      final testUtils = _makePackage(tempDir, 'liquid_flutter_test_utils',
+          workspaceDeps: ['liquid_flutter']);
+      final reactiveForms = _makePackage(tempDir, 'liquid_flutter_reactive_forms',
+          workspaceDeps: ['liquid_flutter']);
+
+      // Deliberately pass in reverse order to verify sorting
+      final sorted = sortPackagesTopologically([reactiveForms, testUtils, core]);
+      final names = sorted.map((p) => p.name).toList();
+
+      expect(names.first, equals('liquid_flutter'));
+      expect(names.indexOf('liquid_flutter'), lessThan(names.indexOf('liquid_flutter_test_utils')));
+      expect(names.indexOf('liquid_flutter'), lessThan(names.indexOf('liquid_flutter_reactive_forms')));
+    });
+
+    test('external (non-workspace) dependencies are ignored', () {
+      final a = _makePackage(tempDir, 'pkg_a');
+      // pkg_b depends on an external package that is not in the workspace
+      final dir = Directory(path.join(tempDir.path, 'pkg_b'))..createSync();
+      File(path.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
+name: pkg_b
+version: 0.1.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  some_external_package: ^1.0.0
+  pkg_a: ^0.1.0
+''');
+      final b = WorkspacePackage(name: 'pkg_b', directory: dir, relativePath: 'pkg_b');
+
+      final sorted = sortPackagesTopologically([b, a]);
+      expect(sorted.map((p) => p.name).toList(), equals(['pkg_a', 'pkg_b']));
+    });
+
+    test('falls back to original order on cycle', () {
+      // Create a cycle: pkg_x depends on pkg_y, pkg_y depends on pkg_x
+      final dirX = Directory(path.join(tempDir.path, 'pkg_x'))..createSync();
+      File(path.join(dirX.path, 'pubspec.yaml')).writeAsStringSync('''
+name: pkg_x
+version: 0.1.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  pkg_y: ^0.1.0
+''');
+      final dirY = Directory(path.join(tempDir.path, 'pkg_y'))..createSync();
+      File(path.join(dirY.path, 'pubspec.yaml')).writeAsStringSync('''
+name: pkg_y
+version: 0.1.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  pkg_x: ^0.1.0
+''');
+      final x = WorkspacePackage(name: 'pkg_x', directory: dirX, relativePath: 'pkg_x');
+      final y = WorkspacePackage(name: 'pkg_y', directory: dirY, relativePath: 'pkg_y');
+
+      // Should not throw; returns original order
+      final sorted = sortPackagesTopologically([x, y]);
+      expect(sorted.map((p) => p.name).toList(), equals(['pkg_x', 'pkg_y']));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Two bugs in workspace versioning caused unreliable version bumps across multiple runs:

**Bug 1 — Ordering**: `updateWorkspaceDependencies` ran as a single pass *after* all packages were versioned. Packages were processed in workspace declaration order, so a consumer package could be versioned before its dependency's pubspec was updated. The dep-constraint bump would then land in a *later* commit, outside the new tag's range, causing another spurious bump on the next CI run.

**Bug 2 — Cascade**: Because the dep bump ended up in a post-tag commit, the next run would see `pubspec.yaml` changes since the last tag and re-version the consumer again indefinitely.

## Fix

- **`workspace_utils.dart`**: Add `sortPackagesTopologically()` (Kahn's algorithm). Builds the intra-workspace dependency graph from each package's `pubspec.yaml` and returns packages in an order where every dependency appears before its consumers. Falls back to the original order on detected cycles (with a warning).

- **`workspace_version.dart`**: Use `sortPackagesTopologically` before the versioning loop. After each package is versioned, immediately call `updateWorkspaceDependencies` for just that package so that downstream consumers see the updated constraint *within the same run*. The dep bump is then captured inside the new tag's range, and subsequent runs start from the new tag with no spurious changes.

## Tests

6 new unit tests in `test/version/workspace_utils_test.dart`:
- No-dependency packages keep their original stable order
- Single dependency: dep comes before dependent
- Diamond dependency graph: correct ordering at all levels
- Real-world scenario: `liquid_flutter` before `test_utils` and `reactive_forms`
- External (non-workspace) dependencies are ignored
- Cycle detection: falls back to original order without throwing